### PR TITLE
Change FMU syntax to use In, Out for parameters

### DIFF
--- a/examples/House/osphouse.smol
+++ b/examples/House/osphouse.smol
@@ -6,7 +6,7 @@ abstract class Wall extends Dynamic()
     abstract Double getH()
 end
 class Outside (Double temp) end
-class Room extends Dynamic(Cont[In Double h_InnerWall, In Double h_OuterWall, In Double h_powerHeater, Out Double T_room] dynamics,
+class Room extends Dynamic(Cont[in Double h_InnerWall, in Double h_OuterWall, in Double h_powerHeater, out Double T_room] dynamics,
                            Wall inner,
                            Wall outer,
                            Controller ctrl,
@@ -28,8 +28,8 @@ class Room extends Dynamic(Cont[In Double h_InnerWall, In Double h_OuterWall, In
         return 0;
     end
 end
-class Controller extends Dynamic(Cont[In Double T_room1, In Double T_room2, In Double T_clock, Out Double h_room1, Out Double h_room2] dynamics,
-                                 Cont[Out Double Clock] clock,
+class Controller extends Dynamic(Cont[in Double T_room1, in Double T_room2, in Double T_clock, out Double h_room1, out Double h_room2] dynamics,
+                                 Cont[out Double Clock] clock,
                                  Room r1,
                                  Room r2)
     override Int propagate()
@@ -44,7 +44,7 @@ class Controller extends Dynamic(Cont[In Double T_room1, In Double T_room2, In D
         return 0;
     end
 end
-class InnerWall extends Wall(Cont[In Double T_room1, In Double T_room2, Out Double h_wall] dynamics, Room left, Room right)
+class InnerWall extends Wall(Cont[in Double T_room1, in Double T_room2, out Double h_wall] dynamics, Room left, Room right)
     override Int propagate()
             this.dynamics.T_room1   := this.left.dynamics.T_room;
             this.dynamics.T_room2   := this.right.dynamics.T_room;
@@ -58,7 +58,7 @@ class InnerWall extends Wall(Cont[In Double T_room1, In Double T_room2, Out Doub
         return this.dynamics.h_wall;
     end
 end
-class OuterWall1 extends Wall(Cont[In Double T_room1, In Double T_outside, Out Double h_wall] dynamics, Room inner, Outside outside)
+class OuterWall1 extends Wall(Cont[in Double T_room1, in Double T_outside, out Double h_wall] dynamics, Room inner, Outside outside)
     override Int propagate()
             this.dynamics.T_room1   := this.inner.dynamics.T_room;
             this.dynamics.T_outside := this.outside.temp;
@@ -72,7 +72,7 @@ class OuterWall1 extends Wall(Cont[In Double T_room1, In Double T_outside, Out D
         return 0;
     end
 end
-class OuterWall2 extends Wall(Cont[In Double T_room2, In Double T_outside, Out Double h_wall] dynamics, Room inner, Outside outside)
+class OuterWall2 extends Wall(Cont[in Double T_room2, in Double T_outside, out Double h_wall] dynamics, Room inner, Outside outside)
     override Int propagate()
             this.dynamics.T_room2   := this.inner.dynamics.T_room;
             this.dynamics.T_outside := this.outside.temp;
@@ -88,15 +88,15 @@ class OuterWall2 extends Wall(Cont[In Double T_room2, In Double T_outside, Out D
 end
 
 main
-    Cont[In Double T_room1, In Double T_room2, Out Double h_wall] i := simulate("examples\House\fmus\InnerWall.fmu");
-    Cont[In Double T_room1, In Double T_outside, Out Double h_wall] o1 := simulate("examples\House\fmus\OuterWall1.fmu");
-    Cont[In Double T_room2, In Double T_outside, Out Double h_wall] o2 := simulate("examples\House\fmus\OuterWall2.fmu");
-    Cont[In Double h_InnerWall, In Double h_OuterWall, In Double h_powerHeater, Out Double T_room] r1 := simulate("examples\House\fmus\Room1.fmu");
+    Cont[in Double T_room1, in Double T_room2, out Double h_wall] i := simulate("examples\House\fmus\InnerWall.fmu");
+    Cont[in Double T_room1, in Double T_outside, out Double h_wall] o1 := simulate("examples\House\fmus\OuterWall1.fmu");
+    Cont[in Double T_room2, in Double T_outside, out Double h_wall] o2 := simulate("examples\House\fmus\OuterWall2.fmu");
+    Cont[in Double h_InnerWall, in Double h_OuterWall, in Double h_powerHeater, out Double T_room] r1 := simulate("examples\House\fmus\Room1.fmu");
     r1.role := "room1";
-    Cont[In Double h_InnerWall, In Double h_OuterWall, In Double h_powerHeater, Out Double T_room] r2 := simulate("examples\House\fmus\Room2.fmu");
+    Cont[in Double h_InnerWall, in Double h_OuterWall, in Double h_powerHeater, out Double T_room] r2 := simulate("examples\House\fmus\Room2.fmu");
     r2.role := "room2";
-    Cont[In Double T_room1, In Double T_room2, In Double T_clock, Out Double h_room1, Out Double h_room2] ctrl := simulate("examples\House\fmus\TempController.fmu");
-    Cont[Out Double Clock] cl := simulate("examples\House\fmus\Clock.fmu", Reset := 100);
+    Cont[in Double T_room1, in Double T_room2, in Double T_clock, out Double h_room1, out Double h_room2] ctrl := simulate("examples\House\fmus\TempController.fmu");
+    Cont[out Double Clock] cl := simulate("examples\House\fmus\Clock.fmu", Reset := 100);
 
 
     Outside outside1 := new Outside(5.3);

--- a/examples/House/osphouse.smol
+++ b/examples/House/osphouse.smol
@@ -6,7 +6,7 @@ abstract class Wall extends Dynamic()
     abstract Double getH()
 end
 class Outside (Double temp) end
-class Room extends Dynamic(Cont[Double h_InnerWall, Double h_OuterWall, Double h_powerHeater; Double T_room] dynamics,
+class Room extends Dynamic(Cont[In Double h_InnerWall, In Double h_OuterWall, In Double h_powerHeater, Out Double T_room] dynamics,
                            Wall inner,
                            Wall outer,
                            Controller ctrl,
@@ -28,8 +28,8 @@ class Room extends Dynamic(Cont[Double h_InnerWall, Double h_OuterWall, Double h
         return 0;
     end
 end
-class Controller extends Dynamic(Cont[Double T_room1, Double T_room2, Double T_clock; Double h_room1, Double h_room2] dynamics,
-                                 Cont[; Double Clock] clock,
+class Controller extends Dynamic(Cont[In Double T_room1, In Double T_room2, In Double T_clock, Out Double h_room1, Out Double h_room2] dynamics,
+                                 Cont[Out Double Clock] clock,
                                  Room r1,
                                  Room r2)
     override Int propagate()
@@ -44,7 +44,7 @@ class Controller extends Dynamic(Cont[Double T_room1, Double T_room2, Double T_c
         return 0;
     end
 end
-class InnerWall extends Wall(Cont[Double T_room1, Double T_room2; Double h_wall] dynamics, Room left, Room right)
+class InnerWall extends Wall(Cont[In Double T_room1, In Double T_room2, Out Double h_wall] dynamics, Room left, Room right)
     override Int propagate()
             this.dynamics.T_room1   := this.left.dynamics.T_room;
             this.dynamics.T_room2   := this.right.dynamics.T_room;
@@ -58,7 +58,7 @@ class InnerWall extends Wall(Cont[Double T_room1, Double T_room2; Double h_wall]
         return this.dynamics.h_wall;
     end
 end
-class OuterWall1 extends Wall(Cont[Double T_room1, Double T_outside; Double h_wall] dynamics, Room inner, Outside outside)
+class OuterWall1 extends Wall(Cont[In Double T_room1, In Double T_outside, Out Double h_wall] dynamics, Room inner, Outside outside)
     override Int propagate()
             this.dynamics.T_room1   := this.inner.dynamics.T_room;
             this.dynamics.T_outside := this.outside.temp;
@@ -72,7 +72,7 @@ class OuterWall1 extends Wall(Cont[Double T_room1, Double T_outside; Double h_wa
         return 0;
     end
 end
-class OuterWall2 extends Wall(Cont[Double T_room2, Double T_outside; Double h_wall] dynamics, Room inner, Outside outside)
+class OuterWall2 extends Wall(Cont[In Double T_room2, In Double T_outside, Out Double h_wall] dynamics, Room inner, Outside outside)
     override Int propagate()
             this.dynamics.T_room2   := this.inner.dynamics.T_room;
             this.dynamics.T_outside := this.outside.temp;
@@ -88,15 +88,15 @@ class OuterWall2 extends Wall(Cont[Double T_room2, Double T_outside; Double h_wa
 end
 
 main
-    Cont[Double T_room1, Double T_room2; Double h_wall] i := simulate("examples\House\fmus\InnerWall.fmu");
-    Cont[Double T_room1, Double T_outside; Double h_wall] o1 := simulate("examples\House\fmus\OuterWall1.fmu");
-    Cont[Double T_room2, Double T_outside; Double h_wall] o2 := simulate("examples\House\fmus\OuterWall2.fmu");
-    Cont[Double h_InnerWall, Double h_OuterWall, Double h_powerHeater; Double T_room] r1 := simulate("examples\House\fmus\Room1.fmu");
+    Cont[In Double T_room1, In Double T_room2, Out Double h_wall] i := simulate("examples\House\fmus\InnerWall.fmu");
+    Cont[In Double T_room1, In Double T_outside, Out Double h_wall] o1 := simulate("examples\House\fmus\OuterWall1.fmu");
+    Cont[In Double T_room2, In Double T_outside, Out Double h_wall] o2 := simulate("examples\House\fmus\OuterWall2.fmu");
+    Cont[In Double h_InnerWall, In Double h_OuterWall, In Double h_powerHeater, Out Double T_room] r1 := simulate("examples\House\fmus\Room1.fmu");
     r1.role := "room1";
-    Cont[Double h_InnerWall, Double h_OuterWall, Double h_powerHeater; Double T_room] r2 := simulate("examples\House\fmus\Room2.fmu");
+    Cont[In Double h_InnerWall, In Double h_OuterWall, In Double h_powerHeater, Out Double T_room] r2 := simulate("examples\House\fmus\Room2.fmu");
     r2.role := "room2";
-    Cont[Double T_room1, Double T_room2, Double T_clock; Double h_room1, Double h_room2] ctrl := simulate("examples\House\fmus\TempController.fmu");
-    Cont[;Double Clock] cl := simulate("examples\House\fmus\Clock.fmu", Reset := 100);
+    Cont[In Double T_room1, In Double T_room2, In Double T_clock, Out Double h_room1, Out Double h_room2] ctrl := simulate("examples\House\fmus\TempController.fmu");
+    Cont[Out Double Clock] cl := simulate("examples\House\fmus\Clock.fmu", Reset := 100);
 
 
     Outside outside1 := new Outside(5.3);

--- a/examples/Orchestrate/Gauss.smol
+++ b/examples/Orchestrate/Gauss.smol
@@ -49,22 +49,22 @@ class CoSim(List<Connection> list, List<Cont[]> sims, Double stepSize)
 end
 
 //example
-class PreyOutPort extends OutPort<Double>(Cont[In Double y, Out Double x] x)
+class PreyOutPort extends OutPort<Double>(Cont[in Double y, out Double x] x)
     override Double get() return this.x.x; end
 end
-class PredatorOutPort extends OutPort<Double>(Cont[In Double x, Out Double y] y)
+class PredatorOutPort extends OutPort<Double>(Cont[in Double x, out Double y] y)
     override Double get() return this.y.y; end
 end
-class PreyInPort extends InPort<Double>(Cont[In Double y, Out Double x] y)
+class PreyInPort extends InPort<Double>(Cont[in Double y, out Double x] y)
     override Boolean write(Double t) this.y.y := t; return True; end
 end
-class PredatorInPort extends InPort<Double>(Cont[In Double x, Out Double y] x)
+class PredatorInPort extends InPort<Double>(Cont[in Double x, out Double y] x)
     override Boolean write(Double t) print(t); this.x.x := t; return True; end
 end
 
 main
-    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     PreyOutPort preyOut := new PreyOutPort(prey);
     PredatorOutPort predOut := new PredatorOutPort(predator);
     PreyInPort preyIn := new PreyInPort(prey);

--- a/examples/Orchestrate/Gauss.smol
+++ b/examples/Orchestrate/Gauss.smol
@@ -22,7 +22,7 @@ class ImplConnection extends Connection (OutPort<Double> from, InPort<Double> to
 end
 
 //Gauss master algorithm: propagate through all FMUs, advance time for all FMUs at once
-class CoSim(List<Connection> list, List<Cont[;]> sims, Double stepSize)
+class CoSim(List<Connection> list, List<Cont[]> sims, Double stepSize)
     Int round()
         Int i := 0;
         if this.list = null then return i; end
@@ -31,7 +31,7 @@ class CoSim(List<Connection> list, List<Cont[;]> sims, Double stepSize)
         while i < length do
             Connection c := this.list.get(i);
             c.propagate();
-            Cont[;] de := this.sims.get(i); //note: we do check here that we do not advance twice if an FMU has two output connections
+            Cont[] de := this.sims.get(i); //note: we do check here that we do not advance twice if an FMU has two output connections
             de.tick(this.stepSize);
             i := i+1;
         end
@@ -49,30 +49,30 @@ class CoSim(List<Connection> list, List<Cont[;]> sims, Double stepSize)
 end
 
 //example
-class PreyOutPort extends OutPort<Double>(Cont[Double y; Double x] x)
+class PreyOutPort extends OutPort<Double>(Cont[In Double y, Out Double x] x)
     override Double get() return this.x.x; end
 end
-class PredatorOutPort extends OutPort<Double>(Cont[Double x; Double y] y)
+class PredatorOutPort extends OutPort<Double>(Cont[In Double x, Out Double y] y)
     override Double get() return this.y.y; end
 end
-class PreyInPort extends InPort<Double>(Cont[Double y; Double x] y)
+class PreyInPort extends InPort<Double>(Cont[In Double y, Out Double x] y)
     override Boolean write(Double t) this.y.y := t; return True; end
 end
-class PredatorInPort extends InPort<Double>(Cont[Double x; Double y] x)
+class PredatorInPort extends InPort<Double>(Cont[In Double x, Out Double y] x)
     override Boolean write(Double t) print(t); this.x.x := t; return True; end
 end
 
 main
-    Cont[Double y; Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[Double x; Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     PreyOutPort preyOut := new PreyOutPort(prey);
     PredatorOutPort predOut := new PredatorOutPort(predator);
     PreyInPort preyIn := new PreyInPort(prey);
     PredatorInPort predIn := new PredatorInPort(predator);
     Connection c1 := new ImplConnection(preyOut, predIn);
     Connection c2 := new ImplConnection(predOut, preyIn);
-    List<Cont[;]> fmus := new List<Cont[;]>(prey, null);
-    fmus := new List<Cont[;]>(predator, fmus);
+    List<Cont[]> fmus := new List<Cont[]>(prey, null);
+    fmus := new List<Cont[]>(predator, fmus);
     List<Connection> cons := new List<Connection>(c1, null);
     cons := new List<Connection>(c2, cons);
     CoSim sim := new CoSim(cons, fmus, 0.05);

--- a/examples/Orchestrate/Jacobi.smol
+++ b/examples/Orchestrate/Jacobi.smol
@@ -23,7 +23,7 @@ class ImplConnection extends Connection (OutPort<Double> from, InPort<Double> to
 end
 
 //Jacobi master algorithm: propagate through all connections, advance time for all FMUs at once
-class CoSim(List<Connection> list, List<Cont[;]> sims, Double stepSize)
+class CoSim(List<Connection> list, List<Cont[]> sims, Double stepSize)
     Int round()
         Int i := 0;
         if this.list = null then return i; end
@@ -37,7 +37,7 @@ class CoSim(List<Connection> list, List<Cont[;]> sims, Double stepSize)
         if this.sims = null then return i; end
         length := this.sims.length();
         while i < length do
-            Cont[;] de := this.sims.get(i);
+            Cont[] de := this.sims.get(i);
             de.tick(this.stepSize);
             i := i + 1;
         end
@@ -55,30 +55,30 @@ class CoSim(List<Connection> list, List<Cont[;]> sims, Double stepSize)
 end
 
 //example
-class PreyOutPort extends OutPort<Double>(Cont[Double y; Double x] x)
+class PreyOutPort extends OutPort<Double>(Cont[In Double y, Out Double x] x)
     override Double get() return this.x.x; end
 end
-class PredatorOutPort extends OutPort<Double>(Cont[Double x; Double y] y)
+class PredatorOutPort extends OutPort<Double>(Cont[In Double x, Out Double y] y)
     override Double get() return this.y.y; end
 end
-class PreyInPort extends InPort<Double>(Cont[Double y; Double x] y)
+class PreyInPort extends InPort<Double>(Cont[In Double y, Out Double x] y)
     override Boolean write(Double t) this.y.y := t; return True; end
 end
-class PredatorInPort extends InPort<Double>(Cont[Double x; Double y] x)
+class PredatorInPort extends InPort<Double>(Cont[In Double x, Out Double y] x)
     override Boolean write(Double t) print(t); this.x.x := t; return True; end
 end
 
 main
-    Cont[Double y; Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[Double x; Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     PreyOutPort preyOut := new PreyOutPort(prey);
     PredatorOutPort predOut := new PredatorOutPort(predator);
     PreyInPort preyIn := new PreyInPort(prey);
     PredatorInPort predIn := new PredatorInPort(predator);
     Connection c1 := new ImplConnection(preyOut, predIn);
     Connection c2 := new ImplConnection(predOut, preyIn);
-    List<Cont[;]> fmus := new List<Cont[;]>(prey, null);
-    fmus := new List<Cont[;]>(predator, fmus);
+    List<Cont[]> fmus := new List<Cont[]>(prey, null);
+    fmus := new List<Cont[]>(predator, fmus);
     List<Connection> cons := new List<Connection>(c1, null);
     cons := new List<Connection>(c2, cons);
     CoSim sim := new CoSim(cons, fmus, 0.01);

--- a/examples/Orchestrate/Jacobi.smol
+++ b/examples/Orchestrate/Jacobi.smol
@@ -55,22 +55,22 @@ class CoSim(List<Connection> list, List<Cont[]> sims, Double stepSize)
 end
 
 //example
-class PreyOutPort extends OutPort<Double>(Cont[In Double y, Out Double x] x)
+class PreyOutPort extends OutPort<Double>(Cont[in Double y, out Double x] x)
     override Double get() return this.x.x; end
 end
-class PredatorOutPort extends OutPort<Double>(Cont[In Double x, Out Double y] y)
+class PredatorOutPort extends OutPort<Double>(Cont[in Double x, out Double y] y)
     override Double get() return this.y.y; end
 end
-class PreyInPort extends InPort<Double>(Cont[In Double y, Out Double x] y)
+class PreyInPort extends InPort<Double>(Cont[in Double y, out Double x] y)
     override Boolean write(Double t) this.y.y := t; return True; end
 end
-class PredatorInPort extends InPort<Double>(Cont[In Double x, Out Double y] x)
+class PredatorInPort extends InPort<Double>(Cont[in Double x, out Double y] x)
     override Boolean write(Double t) print(t); this.x.x := t; return True; end
 end
 
 main
-    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     PreyOutPort preyOut := new PreyOutPort(prey);
     PredatorOutPort predOut := new PredatorOutPort(predator);
     PreyInPort preyIn := new PreyInPort(prey);

--- a/examples/Shadow/detect.smol
+++ b/examples/Shadow/detect.smol
@@ -1,9 +1,9 @@
 class Shadow(Double value, Double assumedSlope)
 
-    Cont[; Double value] findNewShadow(Double lastVal, Double sysVal)
+    Cont[Out Double value] findNewShadow(Double lastVal, Double sysVal)
         print("Anomaly detected, searching for new shadow.");
         Double step := 0.0;
-        Cont[; Double value] shadow := null;
+        Cont[Out Double value] shadow := null;
         while step <= 5 do
             Double assumedSlope := this.assumedSlope + step * 0.2;
             shadow := simulate("examples/Shadow/Sim.fmu", iValue := lastVal, slope := assumedSlope);
@@ -21,8 +21,8 @@ class Shadow(Double value, Double assumedSlope)
     end
 
     Int run()
-        Cont[; Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := this.value, slope := this.assumedSlope);
-        Cont[; Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
+        Cont[Out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := this.value, slope := this.assumedSlope);
+        Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
 
         Int i := 0;
         Double lastDiff := 0.0;

--- a/examples/Shadow/detect.smol
+++ b/examples/Shadow/detect.smol
@@ -1,9 +1,9 @@
 class Shadow(Double value, Double assumedSlope)
 
-    Cont[Out Double value] findNewShadow(Double lastVal, Double sysVal)
+    Cont[out Double value] findNewShadow(Double lastVal, Double sysVal)
         print("Anomaly detected, searching for new shadow.");
         Double step := 0.0;
-        Cont[Out Double value] shadow := null;
+        Cont[out Double value] shadow := null;
         while step <= 5 do
             Double assumedSlope := this.assumedSlope + step * 0.2;
             shadow := simulate("examples/Shadow/Sim.fmu", iValue := lastVal, slope := assumedSlope);
@@ -21,8 +21,8 @@ class Shadow(Double value, Double assumedSlope)
     end
 
     Int run()
-        Cont[Out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := this.value, slope := this.assumedSlope);
-        Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
+        Cont[out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := this.value, slope := this.assumedSlope);
+        Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
 
         Int i := 0;
         Double lastDiff := 0.0;

--- a/examples/Shadow/series.smol
+++ b/examples/Shadow/series.smol
@@ -38,7 +38,7 @@ class ExplorationShadow(Double value, Double assumedSlope, Buffer buffer)
     Double runAndCompare(Int l, Buffer record)
         this.buffer := new Buffer(l, null);
         this.buffer.init();
-        Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
+        Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
         Int i := 0;
         while i < l do
             this.buffer.add(shadow.value);
@@ -51,11 +51,11 @@ class ExplorationShadow(Double value, Double assumedSlope, Buffer buffer)
 end
 
 //requires system != null && bufferSystem == null && bufferShadow == null && limit > 0 && recordLength > 0
-class MonitorShadow(Cont[Out Double value] system, Double value, Double assumedSlope, Buffer bufferSystem, Buffer bufferShadow, Int limit, Int recordLength)
+class MonitorShadow(Cont[out Double value] system, Double value, Double assumedSlope, Buffer bufferSystem, Buffer bufferShadow, Int limit, Int recordLength)
     Unit run()
         print("Start");
         Int step := 0;
-        Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
+        Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
         this.bufferSystem := new Buffer(this.recordLength, null);
         this.bufferSystem.init();
         this.bufferSystem.add(this.system.value);
@@ -86,7 +86,7 @@ class MonitorShadow(Cont[Out Double value] system, Double value, Double assumedS
         print("End");
     end
 
-    Cont[Out Double value] findNewShadow()
+    Cont[out Double value] findNewShadow()
         print("Anomaly detected, searching for new shadow.");
         Double step := 0.0;
         ExplorationShadow explore := null;
@@ -99,7 +99,7 @@ class MonitorShadow(Cont[Out Double value] system, Double value, Double assumedS
                 print(diff);
                 print(mySlope);
                 Double toStart := this.bufferSystem.content.last();
-                Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := toStart, slope := mySlope);
+                Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := toStart, slope := mySlope);
                 return shadow;
             end
             step := step + 1.0;
@@ -110,7 +110,7 @@ class MonitorShadow(Cont[Out Double value] system, Double value, Double assumedS
 end
 
 main
-    Cont[Out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2.0, slope := 1.0);
+    Cont[out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2.0, slope := 1.0);
     MonitorShadow monitor := new MonitorShadow(system, 2.0, 1.0, null, null, 200, 3);
     monitor.run();
 end

--- a/examples/Shadow/series.smol
+++ b/examples/Shadow/series.smol
@@ -38,7 +38,7 @@ class ExplorationShadow(Double value, Double assumedSlope, Buffer buffer)
     Double runAndCompare(Int l, Buffer record)
         this.buffer := new Buffer(l, null);
         this.buffer.init();
-        Cont[; Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
+        Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
         Int i := 0;
         while i < l do
             this.buffer.add(shadow.value);
@@ -51,11 +51,11 @@ class ExplorationShadow(Double value, Double assumedSlope, Buffer buffer)
 end
 
 //requires system != null && bufferSystem == null && bufferShadow == null && limit > 0 && recordLength > 0
-class MonitorShadow(Cont[; Double value] system, Double value, Double assumedSlope, Buffer bufferSystem, Buffer bufferShadow, Int limit, Int recordLength)
+class MonitorShadow(Cont[Out Double value] system, Double value, Double assumedSlope, Buffer bufferSystem, Buffer bufferShadow, Int limit, Int recordLength)
     Unit run()
         print("Start");
         Int step := 0;
-        Cont[; Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
+        Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
         this.bufferSystem := new Buffer(this.recordLength, null);
         this.bufferSystem.init();
         this.bufferSystem.add(this.system.value);
@@ -86,7 +86,7 @@ class MonitorShadow(Cont[; Double value] system, Double value, Double assumedSlo
         print("End");
     end
 
-    Cont[; Double value] findNewShadow()
+    Cont[Out Double value] findNewShadow()
         print("Anomaly detected, searching for new shadow.");
         Double step := 0.0;
         ExplorationShadow explore := null;
@@ -99,7 +99,7 @@ class MonitorShadow(Cont[; Double value] system, Double value, Double assumedSlo
                 print(diff);
                 print(mySlope);
                 Double toStart := this.bufferSystem.content.last();
-                Cont[; Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := toStart, slope := mySlope);
+                Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := toStart, slope := mySlope);
                 return shadow;
             end
             step := step + 1.0;
@@ -110,7 +110,7 @@ class MonitorShadow(Cont[; Double value] system, Double value, Double assumedSlo
 end
 
 main
-    Cont[; Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2.0, slope := 1.0);
+    Cont[Out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2.0, slope := 1.0);
     MonitorShadow monitor := new MonitorShadow(system, 2.0, 1.0, null, null, 200, 3);
     monitor.run();
 end

--- a/examples/Shadow/shadow.smol
+++ b/examples/Shadow/shadow.smol
@@ -1,7 +1,7 @@
 main
 
-    Cont[; Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2, slope := 1);
-    Cont[; Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := 2, slope := 1);
+    Cont[Out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2, slope := 1);
+    Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := 2, slope := 1);
 
     Int i := 0;
     while i <= 200 do

--- a/examples/Shadow/shadow.smol
+++ b/examples/Shadow/shadow.smol
@@ -1,7 +1,7 @@
 main
 
-    Cont[Out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2, slope := 1);
-    Cont[Out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := 2, slope := 1);
+    Cont[out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2, slope := 1);
+    Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := 2, slope := 1);
 
     Int i := 0;
     while i <= 200 do

--- a/examples/SimulationDemo/Linear.smol
+++ b/examples/SimulationDemo/Linear.smol
@@ -1,6 +1,6 @@
 main
-    Cont[Out Int outPort, Out Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
-    Cont[In Int inPort, Out Int outPort, Out Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
+    Cont[out Int outPort, out Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
+    Cont[in Int inPort, out Int outPort, out Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
     Int i := 0;
     while(i <= 50) do
         Int leak := de1.leak;

--- a/examples/SimulationDemo/Linear.smol
+++ b/examples/SimulationDemo/Linear.smol
@@ -1,6 +1,6 @@
 main
-    Cont[; Int outPort, Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
-    Cont[Int inPort; Int outPort, Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
+    Cont[Out Int outPort, Out Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
+    Cont[In Int inPort, Out Int outPort, Out Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
     Int i := 0;
     while(i <= 50) do
         Int leak := de1.leak;

--- a/examples/SimulationDemo/LinearObjects.smol
+++ b/examples/SimulationDemo/LinearObjects.smol
@@ -1,6 +1,6 @@
 
 
-class WrappedSimulator(Cont[In Int inPort, Out Int outPort, Out Int leak] content) end
+class WrappedSimulator(Cont[in Int inPort, out Int outPort, out Int leak] content) end
 
 class Connection(WrappedSimulator from, WrappedSimulator to)
     Int propagate()
@@ -44,8 +44,8 @@ class CoSim(List<Connection> list, List<WrappedSimulator> sims)
 end
 
 main
-    Cont[In Int inPort, Out Int outPort, Out Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
-    Cont[In Int inPort, Out Int outPort, Out Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
+    Cont[in Int inPort, out Int outPort, out Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
+    Cont[in Int inPort, out Int outPort, out Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
     WrappedSimulator s1 := new WrappedSimulator(de1);
     WrappedSimulator s2 := new WrappedSimulator(de2);
     Connection c := new Connection(s1, s2);

--- a/examples/SimulationDemo/LinearObjects.smol
+++ b/examples/SimulationDemo/LinearObjects.smol
@@ -1,6 +1,6 @@
 
 
-class WrappedSimulator(Cont[Int inPort; Int outPort, Int leak] content) end
+class WrappedSimulator(Cont[In Int inPort, Out Int outPort, Out Int leak] content) end
 
 class Connection(WrappedSimulator from, WrappedSimulator to)
     Int propagate()
@@ -35,7 +35,7 @@ class CoSim(List<Connection> list, List<WrappedSimulator> sims)
         length := this.sims.length();
         while i < length do
             WrappedSimulator s := this.sims.get(i);
-            Cont[;] de := s.content;
+            Cont[] de := s.content;
             de.tick(t);
             i := i + 1;
         end
@@ -44,8 +44,8 @@ class CoSim(List<Connection> list, List<WrappedSimulator> sims)
 end
 
 main
-    Cont[Int inPort; Int outPort, Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
-    Cont[Int inPort; Int outPort, Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
+    Cont[In Int inPort, Out Int outPort, Out Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
+    Cont[In Int inPort, Out Int outPort, Out Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
     WrappedSimulator s1 := new WrappedSimulator(de1);
     WrappedSimulator s2 := new WrappedSimulator(de2);
     Connection c := new Connection(s1, s2);

--- a/examples/SimulationDemo/Tank.smol
+++ b/examples/SimulationDemo/Tank.smol
@@ -1,6 +1,6 @@
 main
     //beware: path is relative to interpreter instance, not this file
-    Cont[; Int filling] de := simulate("examples/SimulationDemo/Tank.fmu");
+    Cont[Out Int filling] de := simulate("examples/SimulationDemo/Tank.fmu");
     Int i := de.filling;
     print(i);
     de.tick(1);

--- a/examples/SimulationDemo/Tank.smol
+++ b/examples/SimulationDemo/Tank.smol
@@ -1,6 +1,6 @@
 main
     //beware: path is relative to interpreter instance, not this file
-    Cont[Out Int filling] de := simulate("examples/SimulationDemo/Tank.fmu");
+    Cont[out Int filling] de := simulate("examples/SimulationDemo/Tank.fmu");
     Int i := de.filling;
     print(i);
     de.tick(1);

--- a/examples/SimulationDemo/lotka-volterra.smol
+++ b/examples/SimulationDemo/lotka-volterra.smol
@@ -3,12 +3,12 @@ class UnitObject()
     Double set(Double v) return v; end
     Double doStep(Double step) return step; end
 end
-class PreyObject extends UnitObject (Cont[Double y; Double x] prey)
+class PreyObject extends UnitObject (Cont[In Double y, Out Double x] prey)
     override Double get() return this.prey.x; end
     override Double set(Double v) this.prey.y := v; return v; end
     override Double doStep(Double step) this.prey.tick(step); return step; end
 end
-class PredatorObject extends UnitObject (Cont[Double x; Double y] predator)
+class PredatorObject extends UnitObject (Cont[In Double x, Out Double y] predator)
     override Double get() return this.predator.y; end
     override Double set(Double v) this.predator.x := v; return v; end
     override Double doStep(Double step) this.predator.tick(step); return step; end
@@ -28,8 +28,8 @@ main
 
     //beware: path is relative to interpreter instance, not this file
     //fmus are not uploaded, download them from the MasterSim examples: https://sourceforge.net/projects/mastersim/
-    Cont[Double y; Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[Double x; Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     PreyObject preyObj := new PreyObject(prey);
     PredatorObject predObj := new PredatorObject(predator);
     CoupledPair pair := new CoupledPair(preyObj, predObj, 0.1);

--- a/examples/SimulationDemo/lotka-volterra.smol
+++ b/examples/SimulationDemo/lotka-volterra.smol
@@ -3,12 +3,12 @@ class UnitObject()
     Double set(Double v) return v; end
     Double doStep(Double step) return step; end
 end
-class PreyObject extends UnitObject (Cont[In Double y, Out Double x] prey)
+class PreyObject extends UnitObject (Cont[in Double y, out Double x] prey)
     override Double get() return this.prey.x; end
     override Double set(Double v) this.prey.y := v; return v; end
     override Double doStep(Double step) this.prey.tick(step); return step; end
 end
-class PredatorObject extends UnitObject (Cont[In Double x, Out Double y] predator)
+class PredatorObject extends UnitObject (Cont[in Double x, out Double y] predator)
     override Double get() return this.predator.y; end
     override Double set(Double v) this.predator.x := v; return v; end
     override Double doStep(Double step) this.predator.tick(step); return step; end
@@ -28,8 +28,8 @@ main
 
     //beware: path is relative to interpreter instance, not this file
     //fmus are not uploaded, download them from the MasterSim examples: https://sourceforge.net/projects/mastersim/
-    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     PreyObject preyObj := new PreyObject(prey);
     PredatorObject predObj := new PredatorObject(predator);
     CoupledPair pair := new CoupledPair(preyObj, predObj, 0.1);

--- a/examples/SimulationDemo/lv-plus.smol
+++ b/examples/SimulationDemo/lv-plus.smol
@@ -1,9 +1,9 @@
 main
     //beware: path is relative to interpreter instance, not this file
     //fmus are not uploaded, download them from the MasterSim examples: https://sourceforge.net/projects/mastersim/
-    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
     prey.role := "prey";
-    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     Int i := 0;
     while (i <= 1000) do
         prey.tick(0.1);

--- a/examples/SimulationDemo/lv-plus.smol
+++ b/examples/SimulationDemo/lv-plus.smol
@@ -1,9 +1,9 @@
 main
     //beware: path is relative to interpreter instance, not this file
     //fmus are not uploaded, download them from the MasterSim examples: https://sourceforge.net/projects/mastersim/
-    Cont[Double y; Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
     prey.role := "prey";
-    Cont[Double x; Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     Int i := 0;
     while (i <= 1000) do
         prey.tick(0.1);

--- a/examples/SimulationDemo/lv-simple.smol
+++ b/examples/SimulationDemo/lv-simple.smol
@@ -1,8 +1,8 @@
 main
     //beware: path is relative to interpreter instance, not this file
     //fmus are not uploaded, download them from the MasterSim examples: https://sourceforge.net/projects/mastersim/
-    Cont[Double y; Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[Double x; Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     Int i := 0;
     while (i <= 2000) do
         prey.tick(0.1);

--- a/examples/SimulationDemo/lv-simple.smol
+++ b/examples/SimulationDemo/lv-simple.smol
@@ -1,8 +1,8 @@
 main
     //beware: path is relative to interpreter instance, not this file
     //fmus are not uploaded, download them from the MasterSim examples: https://sourceforge.net/projects/mastersim/
-    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     Int i := 0;
     while (i <= 2000) do
         prey.tick(0.1);

--- a/src/main/antlr/While.g4
+++ b/src/main/antlr/While.g4
@@ -86,8 +86,8 @@ INFLUXMODE : 'INFLUXDB';
 // Note that the IN, OUT constants are also used in
 // TypeChecker.kt:translateType in the FMU branch; adapt strings there if
 // changing the syntax here
-IN : 'In';
-OUT : 'Out';
+IN : 'in';
+OUT : 'out';
 
 //Names etc.
 fragment DIG : [0-9];

--- a/src/main/antlr/While.g4
+++ b/src/main/antlr/While.g4
@@ -83,6 +83,11 @@ FMU : 'Cont';
 PORT : 'port';
 SPARQLMODE : 'SPARQL';
 INFLUXMODE : 'INFLUXDB';
+// Note that the IN, OUT constants are also used in
+// TypeChecker.kt:translateType in the FMU branch; adapt strings there if
+// changing the syntax here
+IN : 'In';
+OUT : 'Out';
 
 //Names etc.
 fragment DIG : [0-9];
@@ -166,11 +171,13 @@ expression :      THIS                           # this_expression
 
 type : NAME                                                    #simple_type
      | NAME LT typelist GT                                     #nested_type
-     | FMU OBRACK in=paramList? SEMI out=paramList? CBRACK     #fmu_type
+     | FMU OBRACK fmuParamList? CBRACK                         #fmu_type
      ;
 typelist : type (COMMA type)*;
 param : type NAME;
 paramList : param (COMMA param)*;
+fmuparam : direction=(IN | OUT) param;
+fmuParamList : fmuparam (COMMA fmuparam)*;
 fieldDecl : (infer=INFERPRIVATE)? (visibility=visibilitymodifier)? (domain=DOMAIN)? type NAME;
 fieldDeclList : fieldDecl (COMMA fieldDecl)*;
 varInit : NAME ASS expression;

--- a/src/main/kotlin/no/uio/microobject/type/TypeChecker.kt
+++ b/src/main/kotlin/no/uio/microobject/type/TypeChecker.kt
@@ -51,9 +51,12 @@ class TypeChecker(private val ctx: WhileParser.ProgramContext, private val setti
                     ComposedType(lead, ctx.typelist().type().map { translateType(it, className, generics) })
                 }
                 is WhileParser.Fmu_typeContext -> {
-                    val ins = if(ctx.`in` != null) ctx.`in`.param().map { Pair(it.NAME().text, translateType(it.type(), className, generics)) }
+                    // Here we compare against literal strings "In", "Out"; if
+                    // the grammar is changed, adapt the two `filter`
+                    // expressions below accordingly.
+                    val ins = if(ctx.fmuParamList() != null) ctx.fmuParamList().fmuparam().filter { it.direction.text == "In" }.map { Pair(it.param().NAME().text, translateType(it.param().type(), className, generics)) }
                     else emptyList()
-                    val outs = if(ctx.out != null) ctx.out.param().map { Pair(it.NAME().text, translateType(it.type(), className, generics)) }
+                    val outs = if(ctx.fmuParamList() != null) ctx.fmuParamList().fmuparam().filter { it.direction.text == "Out" }.map { Pair(it.param().NAME().text, translateType(it.param().type(), className, generics)) }
                     else emptyList()
                     SimulatorType(ins,outs)
                 }

--- a/src/main/kotlin/no/uio/microobject/type/TypeChecker.kt
+++ b/src/main/kotlin/no/uio/microobject/type/TypeChecker.kt
@@ -51,12 +51,12 @@ class TypeChecker(private val ctx: WhileParser.ProgramContext, private val setti
                     ComposedType(lead, ctx.typelist().type().map { translateType(it, className, generics) })
                 }
                 is WhileParser.Fmu_typeContext -> {
-                    // Here we compare against literal strings "In", "Out"; if
+                    // Here we compare against literal strings "in", "out"; if
                     // the grammar is changed, adapt the two `filter`
                     // expressions below accordingly.
-                    val ins = if(ctx.fmuParamList() != null) ctx.fmuParamList().fmuparam().filter { it.direction.text == "In" }.map { Pair(it.param().NAME().text, translateType(it.param().type(), className, generics)) }
+                    val ins = if(ctx.fmuParamList() != null) ctx.fmuParamList().fmuparam().filter { it.direction.text == "in" }.map { Pair(it.param().NAME().text, translateType(it.param().type(), className, generics)) }
                     else emptyList()
-                    val outs = if(ctx.fmuParamList() != null) ctx.fmuParamList().fmuparam().filter { it.direction.text == "Out" }.map { Pair(it.param().NAME().text, translateType(it.param().type(), className, generics)) }
+                    val outs = if(ctx.fmuParamList() != null) ctx.fmuParamList().fmuparam().filter { it.direction.text == "out" }.map { Pair(it.param().NAME().text, translateType(it.param().type(), className, generics)) }
                     else emptyList()
                     SimulatorType(ins,outs)
                 }

--- a/src/main/kotlin/no/uio/microobject/type/Types.kt
+++ b/src/main/kotlin/no/uio/microobject/type/Types.kt
@@ -31,7 +31,7 @@ abstract class SimpleType : Type() {
 }
 
 data class SimulatorType(val inVar : List<Pair<String, Type>>, val outVar : List<Pair<String, Type>>) : SimpleType() {
-    override fun toString() : String  = "Cont[ ${inVar.joinToString(",") { "In " + it.first + ":" + it.second }}, ${outVar.joinToString(",") { "Out " + it.first + ":" + it.second }}]"
+    override fun toString() : String  = "Cont[ ${inVar.joinToString(",") { "in " + it.first + ":" + it.second }}, ${outVar.joinToString(",") { "out " + it.first + ":" + it.second }}]"
     override fun getNameString() : String  = "Cont"
     override fun isFullyConcrete() : Boolean =
         inVar.map { it.second }.any { it.isFullyConcrete() } && outVar.map { it.second }.any { it.isFullyConcrete() }

--- a/src/main/kotlin/no/uio/microobject/type/Types.kt
+++ b/src/main/kotlin/no/uio/microobject/type/Types.kt
@@ -31,7 +31,7 @@ abstract class SimpleType : Type() {
 }
 
 data class SimulatorType(val inVar : List<Pair<String, Type>>, val outVar : List<Pair<String, Type>>) : SimpleType() {
-    override fun toString() : String  = "Cont[ ${inVar.joinToString(",") { it.first + ":" + it.second }}; ${outVar.joinToString(",") { it.first + ":" + it.second }}]"
+    override fun toString() : String  = "Cont[ ${inVar.joinToString(",") { "In " + it.first + ":" + it.second }}, ${outVar.joinToString(",") { "Out " + it.first + ":" + it.second }}]"
     override fun getNameString() : String  = "Cont"
     override fun isFullyConcrete() : Boolean =
         inVar.map { it.second }.any { it.isFullyConcrete() } && outVar.map { it.second }.any { it.isFullyConcrete() }

--- a/src/test/kotlin/no/uio/microobject/test/execution/FMOLExecutionTest.kt
+++ b/src/test/kotlin/no/uio/microobject/test/execution/FMOLExecutionTest.kt
@@ -11,7 +11,7 @@ class FMOLExecutionTest: MicroObjectTest() {
     init {
         "adder 1" {
             val stmt = """
-                Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu", ra := 1.0, rb := 1.0);
+                Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu", ra := 1.0, rb := 1.0);
                 Double res := fmu1.rc;
                 breakpoint;
                 print(res);
@@ -23,7 +23,7 @@ class FMOLExecutionTest: MicroObjectTest() {
         }
         "linear 1" {
             val stmt = """
-                Cont[; Int outPort] fmu1 := simulate("src/test/resources/linear.fmu", inPort := 1);
+                Cont[Out Int outPort] fmu1 := simulate("src/test/resources/linear.fmu", inPort := 1);
                 fmu1.tick(1.0);
                 Int res := fmu1.outPort;
                 breakpoint;

--- a/src/test/kotlin/no/uio/microobject/test/execution/FMOLExecutionTest.kt
+++ b/src/test/kotlin/no/uio/microobject/test/execution/FMOLExecutionTest.kt
@@ -11,7 +11,7 @@ class FMOLExecutionTest: MicroObjectTest() {
     init {
         "adder 1" {
             val stmt = """
-                Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu", ra := 1.0, rb := 1.0);
+                Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu", ra := 1.0, rb := 1.0);
                 Double res := fmu1.rc;
                 breakpoint;
                 print(res);
@@ -23,7 +23,7 @@ class FMOLExecutionTest: MicroObjectTest() {
         }
         "linear 1" {
             val stmt = """
-                Cont[Out Int outPort] fmu1 := simulate("src/test/resources/linear.fmu", inPort := 1);
+                Cont[out Int outPort] fmu1 := simulate("src/test/resources/linear.fmu", inPort := 1);
                 fmu1.tick(1.0);
                 Int res := fmu1.outPort;
                 breakpoint;

--- a/src/test/resources/Jacobi.smol
+++ b/src/test/resources/Jacobi.smol
@@ -22,7 +22,7 @@ class ImplConnection extends Connection (OutPort<Double> from, InPort<Double> to
 end
 
 //Jacobi master algorithm: propagate through all connections, advance time for all FMUs at once
-class CoSim(List<Connection> list, List<Cont[;]> sims, Double stepSize)
+class CoSim(List<Connection> list, List<Cont[]> sims, Double stepSize)
     Int round()
         Int i := 0;
         if this.list = null then return i; end
@@ -36,7 +36,7 @@ class CoSim(List<Connection> list, List<Cont[;]> sims, Double stepSize)
         if this.sims = null then return i; end
         length := this.sims.length();
         while i < length do
-            Cont[;] de := this.sims.get(i);
+            Cont[] de := this.sims.get(i);
             de.tick(this.stepSize);
             i := i + 1;
         end
@@ -54,30 +54,30 @@ class CoSim(List<Connection> list, List<Cont[;]> sims, Double stepSize)
 end
 
 //example
-class PreyOutPort extends OutPort<Double>(Cont[Double y; Double x] prey)
+class PreyOutPort extends OutPort<Double>(Cont[In Double y, Out Double x] prey)
     override Double get() return this.prey.x; end
 end
-class PredatorOutPort extends OutPort<Double>(Cont[Double x; Double y] predator)
+class PredatorOutPort extends OutPort<Double>(Cont[In Double x, Out Double y] predator)
     override Double get() return this.predator.y; end
 end
-class PreyInPort extends InPort<Double>(Cont[Double y; Double x] prey)
+class PreyInPort extends InPort<Double>(Cont[In Double y, Out Double x] prey)
     override Boolean write(Double t) this.prey.y := t; return True; end
 end
-class PredatorInPort extends InPort<Double>(Cont[Double x; Double y] predator)
+class PredatorInPort extends InPort<Double>(Cont[In Double x, Out Double y] predator)
     override Boolean write(Double t) print(t); this.predator.x := t; return True; end
 end
 
 main
-    Cont[Double y; Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[Double x; Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     PreyOutPort preyOut := new PreyOutPort(prey);
     PredatorOutPort predOut := new PredatorOutPort(predator);
     PreyInPort preyIn := new PreyInPort(prey);
     PredatorInPort predIn := new PredatorInPort(predator);
     Connection c1 := new ImplConnection(preyOut, predIn);
     Connection c2 := new ImplConnection(predOut, preyIn);
-    List<Cont[;]> fmus := new List<Cont[;]>(prey, null);
-    fmus := new List<Cont[;]>(predator, fmus);
+    List<Cont[]> fmus := new List<Cont[]>(prey, null);
+    fmus := new List<Cont[]>(predator, fmus);
     List<Connection> cons := new List<Connection>(c1, null);
     cons := new List<Connection>(c2, cons);
     CoSim sim := new CoSim(cons, fmus, 0.2);

--- a/src/test/resources/Jacobi.smol
+++ b/src/test/resources/Jacobi.smol
@@ -54,22 +54,22 @@ class CoSim(List<Connection> list, List<Cont[]> sims, Double stepSize)
 end
 
 //example
-class PreyOutPort extends OutPort<Double>(Cont[In Double y, Out Double x] prey)
+class PreyOutPort extends OutPort<Double>(Cont[in Double y, out Double x] prey)
     override Double get() return this.prey.x; end
 end
-class PredatorOutPort extends OutPort<Double>(Cont[In Double x, Out Double y] predator)
+class PredatorOutPort extends OutPort<Double>(Cont[in Double x, out Double y] predator)
     override Double get() return this.predator.y; end
 end
-class PreyInPort extends InPort<Double>(Cont[In Double y, Out Double x] prey)
+class PreyInPort extends InPort<Double>(Cont[in Double y, out Double x] prey)
     override Boolean write(Double t) this.prey.y := t; return True; end
 end
-class PredatorInPort extends InPort<Double>(Cont[In Double x, Out Double y] predator)
+class PredatorInPort extends InPort<Double>(Cont[in Double x, out Double y] predator)
     override Boolean write(Double t) print(t); this.predator.x := t; return True; end
 end
 
 main
-    Cont[In Double y, Out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[In Double x, Out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
+    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
+    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
     PreyOutPort preyOut := new PreyOutPort(prey);
     PredatorOutPort predOut := new PredatorOutPort(predator);
     PreyInPort preyIn := new PreyInPort(prey);

--- a/src/test/resources/test_fmu.smol
+++ b/src/test/resources/test_fmu.smol
@@ -1,19 +1,19 @@
 class SuccessClass()
     Int start()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[Double ra, Double rb; ] fmu2 := simulate("src/test/resources/adder.fmu");
-        Cont[Double rb; Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
-        Cont[;] fmu4 := simulate("src/test/resources/adder.fmu");
-        Cont[Double ra, Double rb; Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb ] fmu2 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double rb, Out Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
+        Cont[] fmu4 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
         return 1;
     end
 
     Int assign()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[Double ra, Double rb; ] fmu2 := simulate("src/test/resources/adder.fmu");
-        Cont[Double rb; Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
-        Cont[;] fmu4 := simulate("src/test/resources/adder.fmu");
-        Cont[Double ra, Double rb; Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb] fmu2 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double rb, Out Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
+        Cont[] fmu4 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
         fmu2 := fmu1;
         fmu3 := fmu1;
         fmu4 := fmu1;
@@ -24,38 +24,38 @@ class SuccessClass()
     end
 
     Int portTest()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         Double dd := fmu1.port("rc");
         fmu1.port("ra") := 2.0;
         return 1;
     end
 
     Int fieldfail1()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         Double g := fmu1.ra;
     end
     Int fieldfail2()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         fmu1.rc := 1.0;
     end
     Int fieldfail3()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         fmu1.rc := 1;
     end
     Int fieldfail4()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         fmu1.rd := 1;
     end
     Int fieldfail5()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         Double dd := fmu1.rd;
     end
     Int fieldfail6()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         Double dd := fmu1.port("rd");
     end
     Int extra(String str, Double param)
-        Cont[;] fmu4 := simulate("src/test/resources/adder.fmu");
+        Cont[] fmu4 := simulate("src/test/resources/adder.fmu");
         fmu4.role := str;
         fmu4.pseudoOffset := param;
         String read := fmu4.role;
@@ -66,31 +66,31 @@ end
 
 class FailClass()
     Int fail1()
-        Cont[Int ra, Int rb; Int rc] fmu1 := simulate("src/test/resources/adder.fmu"); //wrong type
+        Cont[In Int ra, In Int rb, Out Int rc] fmu1 := simulate("src/test/resources/adder.fmu"); //wrong type
         return 1;
     end
     Int fail2()
-        Cont[Double rc; Double ra, Double rb] fmu5 := simulate("src/test/resources/adder.fmu"); //wrong order
+        Cont[In Double rc, Out Double ra, Out Double rb] fmu5 := simulate("src/test/resources/adder.fmu"); //wrong order
         return 1;
     end
     Int fail3()
-        Cont[Double ra, Double rb; Double rc] fmu5 := simulate("src/test/resources/adder.fmu", rc := 0.0); //inits output
+        Cont[In Double ra, In Double rb, Out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", rc := 0.0); //inits output
         return 1;
     end
     Int fail4()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[Int ia, Int ib; Int ic] fmu2 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Int ia, In Int ib, Out Int ic] fmu2 := simulate("src/test/resources/adder.fmu");
         fmu2 := fmu1;
         return 1;
     end
     Int fail5()
-        Cont[Double ra, Double rb; Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[;] fmu2 := simulate("src/test/resources/adder.fmu");
+        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[] fmu2 := simulate("src/test/resources/adder.fmu");
         fmu1 := fmu2;
         return 1;
     end
     Int fail6()
-        Cont[Int rb; Int rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[In Int rb, Out Int rc] fmu1 := simulate("src/test/resources/adder.fmu");
         return 1;
     end
 end

--- a/src/test/resources/test_fmu.smol
+++ b/src/test/resources/test_fmu.smol
@@ -1,19 +1,19 @@
 class SuccessClass()
     Int start()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[In Double ra, In Double rb ] fmu2 := simulate("src/test/resources/adder.fmu");
-        Cont[In Double rb, Out Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb ] fmu2 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double rb, out Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
         Cont[] fmu4 := simulate("src/test/resources/adder.fmu");
-        Cont[In Double ra, In Double rb, Out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
+        Cont[in Double ra, in Double rb, out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
         return 1;
     end
 
     Int assign()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[In Double ra, In Double rb] fmu2 := simulate("src/test/resources/adder.fmu");
-        Cont[In Double rb, Out Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb] fmu2 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double rb, out Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
         Cont[] fmu4 := simulate("src/test/resources/adder.fmu");
-        Cont[In Double ra, In Double rb, Out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
+        Cont[in Double ra, in Double rb, out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
         fmu2 := fmu1;
         fmu3 := fmu1;
         fmu4 := fmu1;
@@ -24,34 +24,34 @@ class SuccessClass()
     end
 
     Int portTest()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         Double dd := fmu1.port("rc");
         fmu1.port("ra") := 2.0;
         return 1;
     end
 
     Int fieldfail1()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         Double g := fmu1.ra;
     end
     Int fieldfail2()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         fmu1.rc := 1.0;
     end
     Int fieldfail3()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         fmu1.rc := 1;
     end
     Int fieldfail4()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         fmu1.rd := 1;
     end
     Int fieldfail5()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         Double dd := fmu1.rd;
     end
     Int fieldfail6()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         Double dd := fmu1.port("rd");
     end
     Int extra(String str, Double param)
@@ -66,31 +66,31 @@ end
 
 class FailClass()
     Int fail1()
-        Cont[In Int ra, In Int rb, Out Int rc] fmu1 := simulate("src/test/resources/adder.fmu"); //wrong type
+        Cont[in Int ra, in Int rb, out Int rc] fmu1 := simulate("src/test/resources/adder.fmu"); //wrong type
         return 1;
     end
     Int fail2()
-        Cont[In Double rc, Out Double ra, Out Double rb] fmu5 := simulate("src/test/resources/adder.fmu"); //wrong order
+        Cont[in Double rc, out Double ra, out Double rb] fmu5 := simulate("src/test/resources/adder.fmu"); //wrong order
         return 1;
     end
     Int fail3()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", rc := 0.0); //inits output
+        Cont[in Double ra, in Double rb, out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", rc := 0.0); //inits output
         return 1;
     end
     Int fail4()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[In Int ia, In Int ib, Out Int ic] fmu2 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Int ia, in Int ib, out Int ic] fmu2 := simulate("src/test/resources/adder.fmu");
         fmu2 := fmu1;
         return 1;
     end
     Int fail5()
-        Cont[In Double ra, In Double rb, Out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
         Cont[] fmu2 := simulate("src/test/resources/adder.fmu");
         fmu1 := fmu2;
         return 1;
     end
     Int fail6()
-        Cont[In Int rb, Out Int rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Int rb, out Int rc] fmu1 := simulate("src/test/resources/adder.fmu");
         return 1;
     end
 end


### PR DESCRIPTION
- Replace the syntax `Cont[Int x; Int y]` with `Cont[In Int x, Out Int y]`.

- In and Out parameters can be given in any order and do not need to be
  separated with a semicolon `;`.  A FMU with no in- and out-parameters is
  written `Cont[]` instead of `Cont[;]`.