### PR TITLE
Change syntax of assignment, equality, inequality operators

### DIFF
--- a/eval/TTT_class_schema.smol
+++ b/eval/TTT_class_schema.smol
@@ -2,27 +2,27 @@ class Pair(key, value) end
 
 class Node(dataL, dataR, childL, childM, childR, parent)
     add(kv)
-        res := null;
-        if(this.childL = null) then //this is a leaf
-            if(this.dataL = null)  then this.dataL := kv;
+        res = null;
+        if(this.childL == null) then //this is a leaf
+            if(this.dataL == null)  then this.dataL = kv;
             else
-                if (this.dataR = null) then
-                     if (this.dataL.key <= kv.key) then this.dataR := kv;
+                if (this.dataR == null) then
+                     if (this.dataL.key <= kv.key) then this.dataR = kv;
                      else
-                        this.dataR := this.dataL;
-                        this.dataL := kv;
+                        this.dataR = this.dataL;
+                        this.dataL = kv;
                      end
                 else
-                    res := this.createNew(kv);
+                    res = this.createNew(kv);
                 end
             end
         else                    //this is an internal node
-            if(kv.key <= this.dataL.key) then res := this.childL.add(kv);
+            if(kv.key <= this.dataL.key) then res = this.childL.add(kv);
             else
-                if(this.dataR = null) then res := this.childM.add(kv); //this is a 2-node
+                if(this.dataR == null) then res = this.childM.add(kv); //this is a 2-node
                 else                                        //this is a 3-node
-                    if(kv.key <= this.dataR.key) then res := this.childM.add(kv);
-                    else res := this.childR.add(kv);
+                    if(kv.key <= this.dataR.key) then res = this.childM.add(kv);
+                    else res = this.childR.add(kv);
                     end
                 end
              end
@@ -34,68 +34,68 @@ class Node(dataL, dataR, childL, childM, childR, parent)
     createNew(kv)
         //find middle
         if(kv.key <= this.dataL.key) then
-            middle := this.dataL;
-            left := new Node(kv, null, null, null, null, null);
-            right := new Node(this.dataR, null, null, null, null, null);
+            middle = this.dataL;
+            left = new Node(kv, null, null, null, null, null);
+            right = new Node(this.dataR, null, null, null, null, null);
         else
             if (kv.key >= this.dataR.key) then
-                middle := this.dataR;
-                left := new Node(this.dataL, null, null, null, null, null);
-                right := new Node(kv, null, null, null, null, null);
+                middle = this.dataR;
+                left = new Node(this.dataL, null, null, null, null, null);
+                right = new Node(kv, null, null, null, null, null);
             else
-                middle := kv;
-                left := new Node(this.dataL, null, null, null, null, null);
-                right := new Node(this.dataR, null, null, null, null, null);
+                middle = kv;
+                left = new Node(this.dataL, null, null, null, null, null);
+                right = new Node(this.dataR, null, null, null, null, null);
             end
          end
-        newTop := this.repairOrReroot(middle, left, right);
+        newTop = this.repairOrReroot(middle, left, right);
         return newTop;
     end
 
     repair(left, middle, right, from)
-        if(this.dataR = null) then  //internal 2-node
-            if(from = this.childL) then
-                this.dataR := this.dataL;
-                this.dataL := middle;
-                this.childR := this.childM;
-                this.childM := right;
-                this.childL := left;
-                right.parent := this;
-                left.parent := this;
+        if(this.dataR == null) then  //internal 2-node
+            if(from == this.childL) then
+                this.dataR = this.dataL;
+                this.dataL = middle;
+                this.childR = this.childM;
+                this.childM = right;
+                this.childL = left;
+                right.parent = this;
+                left.parent = this;
             else
-                this.dataR := middle;
-                this.childR := right;
-                this.childM := left;
-                right.parent := this;
-                left.parent := this;
+                this.dataR = middle;
+                this.childR = right;
+                this.childM = left;
+                right.parent = this;
+                left.parent = this;
             end
             return this;
         else                        //internal 3-node
-            if(from = this.childL) then
-                 newLeft := new Node(middle, null, left, right, null, null);
-                 left.parent := newLeft;
-                 right.parent := newLeft;
-                 newRight := new Node(this.dataR, null, this.childM, this.childR, null, null);
-                 this.childM.parent := newRight;
-                 this.childR.parent := newRight;
-                 res := this.repairOrReroot(this.dataR, newLeft, newRight);
+            if(from == this.childL) then
+                 newLeft = new Node(middle, null, left, right, null, null);
+                 left.parent = newLeft;
+                 right.parent = newLeft;
+                 newRight = new Node(this.dataR, null, this.childM, this.childR, null, null);
+                 this.childM.parent = newRight;
+                 this.childR.parent = newRight;
+                 res = this.repairOrReroot(this.dataR, newLeft, newRight);
             else
-                if(from = this.childM) then
-                     newLeft := new Node(this.dataL, null, this.childL, left, null, null);
-                     this.childL.parent := newLeft;
-                     left.parent := newLeft;
-                     newRight := new Node(this.dataR, null, right, this.childR, null, null);
-                     right.parent := newRight;
-                     this.childR.parent := newRight;
-                     res := this.repairOrReroot(this.dataR, newLeft, newRight);
+                if(from == this.childM) then
+                     newLeft = new Node(this.dataL, null, this.childL, left, null, null);
+                     this.childL.parent = newLeft;
+                     left.parent = newLeft;
+                     newRight = new Node(this.dataR, null, right, this.childR, null, null);
+                     right.parent = newRight;
+                     this.childR.parent = newRight;
+                     res = this.repairOrReroot(this.dataR, newLeft, newRight);
                 else
-                     newLeft := new Node(this.dataL, null, this.childL, this.childM, null, null);
-                     this.childL.parent := newLeft;
-                     this.childM.parent := newLeft;
-                     newRight := new Node(middle, null, left, right, null, null);
-                     left.parent := newRight;
-                     right.parent := newRight;
-                     res := this.repairOrReroot(this.dataR, newLeft, newRight);
+                     newLeft = new Node(this.dataL, null, this.childL, this.childM, null, null);
+                     this.childL.parent = newLeft;
+                     this.childM.parent = newLeft;
+                     newRight = new Node(middle, null, left, right, null, null);
+                     left.parent = newRight;
+                     right.parent = newRight;
+                     res = this.repairOrReroot(this.dataR, newLeft, newRight);
                 end
             end
         return res;
@@ -103,51 +103,51 @@ class Node(dataL, dataR, childL, childM, childR, parent)
     end
 
     repairOrReroot(middle, left, right)
-        if(this.parent = null) then //root
-            newTop := new Node(middle, null, left, right, null, null);
-            left.parent := newTop;
-            right.parent := newTop;
+        if(this.parent == null) then //root
+            newTop = new Node(middle, null, left, right, null, null);
+            left.parent = newTop;
+            right.parent = newTop;
         else
-            newTop := this.parent.repair(left, middle, right, this);
-            this.parent := null;
+            newTop = this.parent.repair(left, middle, right, this);
+            this.parent = null;
         end
         return newTop;
     end
     retrieve(k)
-       if(this.dataL = null) then res := null; return res; end
-       if(k = this.dataL.key) then res := this.dataL.value; return res; end
-       if(k <= this.dataL.key) then res := this.childL.retrieve(k); return res; end
-       if(this.dataR = null) then res := this.childM.retrieve(k); return res; end
-       if(k = this.dataR.key) then res := this.dataR.value; return res; end
-       if(k <= this.dataR.key) then res := this.childM.retrieve(k); return res; end
-       res := this.childR.retrieve(k);
+       if(this.dataL == null) then res = null; return res; end
+       if(k == this.dataL.key) then res = this.dataL.value; return res; end
+       if(k <= this.dataL.key) then res = this.childL.retrieve(k); return res; end
+       if(this.dataR == null) then res = this.childM.retrieve(k); return res; end
+       if(k == this.dataR.key) then res = this.dataR.value; return res; end
+       if(k <= this.dataR.key) then res = this.childM.retrieve(k); return res; end
+       res = this.childR.retrieve(k);
        return res;
     end
 end
 
 class Tree(root)
     add(kv)
-        res := this.root.add(kv);
-        if(res <> null) then this.root := res; end
+        res = this.root.add(kv);
+        if(res != null) then this.root = res; end
         return 0;
     end
     retrieve(k)
-       res := this.root.retrieve(k);
+       res = this.root.retrieve(k);
        return res;
     end
 end
 
 
 main
-    root := new Node(null, null, null, null, null, null);
-    tree := new Tree(root);
-    pair1 := new Pair(1,"a");
+    root = new Node(null, null, null, null, null, null);
+    tree = new Tree(root);
+    pair1 = new Pair(1,"a");
     tree.add(pair1);
-    i := 2;
+    i = 2;
     while( i <= VAR ) do
-    	pair2 := new Pair(i,"b");
+    	pair2 = new Pair(i,"b");
 	    tree.add(pair2);
-	    i := i + 1;
+	    i = i + 1;
     end
     print("done");
 end

--- a/eval/TTT_rule_schema.smol
+++ b/eval/TTT_rule_schema.smol
@@ -2,27 +2,27 @@ class Pair(key, value) end
 
 class Node(dataL, dataR, childL, childM, childR, parent)
     add(kv)
-        res := null;
-        if(this.childL = null) then //this is a leaf
-            if(this.dataL = null)  then this.dataL := kv;
+        res = null;
+        if(this.childL == null) then //this is a leaf
+            if(this.dataL == null)  then this.dataL = kv;
             else
-                if (this.dataR = null) then
-                     if (this.dataL.key <= kv.key) then this.dataR := kv;
+                if (this.dataR == null) then
+                     if (this.dataL.key <= kv.key) then this.dataR = kv;
                      else
-                        this.dataR := this.dataL;
-                        this.dataL := kv;
+                        this.dataR = this.dataL;
+                        this.dataL = kv;
                      end
                 else
-                    res := this.createNew(kv);
+                    res = this.createNew(kv);
                 end
             end
         else                    //this is an internal node
-            if(kv.key <= this.dataL.key) then res := this.childL.add(kv);
+            if(kv.key <= this.dataL.key) then res = this.childL.add(kv);
             else
-                if(this.dataR = null) then res := this.childM.add(kv); //this is a 2-node
+                if(this.dataR == null) then res = this.childM.add(kv); //this is a 2-node
                 else                                        //this is a 3-node
-                    if(kv.key <= this.dataR.key) then res := this.childM.add(kv);
-                    else res := this.childR.add(kv);
+                    if(kv.key <= this.dataR.key) then res = this.childM.add(kv);
+                    else res = this.childR.add(kv);
                     end
                 end
              end
@@ -34,68 +34,68 @@ class Node(dataL, dataR, childL, childM, childR, parent)
     createNew(kv)
         //find middle
         if(kv.key <= this.dataL.key) then
-            middle := this.dataL;
-            left := new Node(kv, null, null, null, null, null);
-            right := new Node(this.dataR, null, null, null, null, null);
+            middle = this.dataL;
+            left = new Node(kv, null, null, null, null, null);
+            right = new Node(this.dataR, null, null, null, null, null);
         else
             if (kv.key >= this.dataR.key) then
-                middle := this.dataR;
-                left := new Node(this.dataL, null, null, null, null, null);
-                right := new Node(kv, null, null, null, null, null);
+                middle = this.dataR;
+                left = new Node(this.dataL, null, null, null, null, null);
+                right = new Node(kv, null, null, null, null, null);
             else
-                middle := kv;
-                left := new Node(this.dataL, null, null, null, null, null);
-                right := new Node(this.dataR, null, null, null, null, null);
+                middle = kv;
+                left = new Node(this.dataL, null, null, null, null, null);
+                right = new Node(this.dataR, null, null, null, null, null);
             end
          end
-        newTop := this.repairOrReroot(middle, left, right);
+        newTop = this.repairOrReroot(middle, left, right);
         return newTop;
     end
 
     repair(left, middle, right, from)
-        if(this.dataR = null) then  //internal 2-node
-            if(from = this.childL) then
-                this.dataR := this.dataL;
-                this.dataL := middle;
-                this.childR := this.childM;
-                this.childM := right;
-                this.childL := left;
-                right.parent := this;
-                left.parent := this;
+        if(this.dataR == null) then  //internal 2-node
+            if(from == this.childL) then
+                this.dataR = this.dataL;
+                this.dataL = middle;
+                this.childR = this.childM;
+                this.childM = right;
+                this.childL = left;
+                right.parent = this;
+                left.parent = this;
             else
-                this.dataR := middle;
-                this.childR := right;
-                this.childM := left;
-                right.parent := this;
-                left.parent := this;
+                this.dataR = middle;
+                this.childR = right;
+                this.childM = left;
+                right.parent = this;
+                left.parent = this;
             end
             return this;
         else                        //internal 3-node
-            if(from = this.childL) then
-                 newLeft := new Node(middle, null, left, right, null, null);
-                 left.parent := newLeft;
-                 right.parent := newLeft;
-                 newRight := new Node(this.dataR, null, this.childM, this.childR, null, null);
-                 this.childM.parent := newRight;
-                 this.childR.parent := newRight;
-                 res := this.repairOrReroot(this.dataR, newLeft, newRight);
+            if(from == this.childL) then
+                 newLeft = new Node(middle, null, left, right, null, null);
+                 left.parent = newLeft;
+                 right.parent = newLeft;
+                 newRight = new Node(this.dataR, null, this.childM, this.childR, null, null);
+                 this.childM.parent = newRight;
+                 this.childR.parent = newRight;
+                 res = this.repairOrReroot(this.dataR, newLeft, newRight);
             else
-                if(from = this.childM) then
-                     newLeft := new Node(this.dataL, null, this.childL, left, null, null);
-                     this.childL.parent := newLeft;
-                     left.parent := newLeft;
-                     newRight := new Node(this.dataR, null, right, this.childR, null, null);
-                     right.parent := newRight;
-                     this.childR.parent := newRight;
-                     res := this.repairOrReroot(this.dataR, newLeft, newRight);
+                if(from == this.childM) then
+                     newLeft = new Node(this.dataL, null, this.childL, left, null, null);
+                     this.childL.parent = newLeft;
+                     left.parent = newLeft;
+                     newRight = new Node(this.dataR, null, right, this.childR, null, null);
+                     right.parent = newRight;
+                     this.childR.parent = newRight;
+                     res = this.repairOrReroot(this.dataR, newLeft, newRight);
                 else
-                     newLeft := new Node(this.dataL, null, this.childL, this.childM, null, null);
-                     this.childL.parent := newLeft;
-                     this.childM.parent := newLeft;
-                     newRight := new Node(middle, null, left, right, null, null);
-                     left.parent := newRight;
-                     right.parent := newRight;
-                     res := this.repairOrReroot(this.dataR, newLeft, newRight);
+                     newLeft = new Node(this.dataL, null, this.childL, this.childM, null, null);
+                     this.childL.parent = newLeft;
+                     this.childM.parent = newLeft;
+                     newRight = new Node(middle, null, left, right, null, null);
+                     left.parent = newRight;
+                     right.parent = newRight;
+                     res = this.repairOrReroot(this.dataR, newLeft, newRight);
                 end
             end
         return res;
@@ -103,69 +103,69 @@ class Node(dataL, dataR, childL, childM, childR, parent)
     end
 
     repairOrReroot(middle, left, right)
-        if(this.parent = null) then //root
-            newTop := new Node(middle, null, left, right, null, null);
-            left.parent := newTop;
-            right.parent := newTop;
+        if(this.parent == null) then //root
+            newTop = new Node(middle, null, left, right, null, null);
+            left.parent = newTop;
+            right.parent = newTop;
         else
-            newTop := this.parent.repair(left, middle, right, this);
-            this.parent := null;
+            newTop = this.parent.repair(left, middle, right, this);
+            this.parent = null;
         end
         return newTop;
     end
     retrieve(k)
-       if(this.dataL = null) then res := null; return res; end
-       if(k = this.dataL.key) then res := this.dataL.value; return res; end
-       if(k <= this.dataL.key) then res := this.childL.retrieve(k); return res; end
-       if(this.dataR = null) then res := this.childM.retrieve(k); return res; end
-       if(k = this.dataR.key) then res := this.dataR.value; return res; end
-       if(k <= this.dataR.key) then res := this.childM.retrieve(k); return res; end
-       res := this.childR.retrieve(k);
+       if(this.dataL == null) then res = null; return res; end
+       if(k == this.dataL.key) then res = this.dataL.value; return res; end
+       if(k <= this.dataL.key) then res = this.childL.retrieve(k); return res; end
+       if(this.dataR == null) then res = this.childM.retrieve(k); return res; end
+       if(k == this.dataR.key) then res = this.dataR.value; return res; end
+       if(k <= this.dataR.key) then res = this.childM.retrieve(k); return res; end
+       res = this.childR.retrieve(k);
        return res;
     end
 end
 
 class Tree(root)
     add(kv)
-        res := this.root.add(kv);
-        if(res <> null) then this.root := res; end
+        res = this.root.add(kv);
+        if(res != null) then this.root = res; end
         return 0;
     end
     retrieve(k)
-       res := this.root.retrieve(k);
+       res = this.root.retrieve(k);
        return res;
     end
 end
 
 class Wrap(ttt, key)
     rule lookup()
-        v := this.ttt.retrieve(this.key);
+        v = this.ttt.retrieve(this.key);
         return v;
     end
 end
 
 class List(content, next)
     length()
-        if(this.next = null) then return 1;
-        else n := this.next.length(); return n + 1; end
+        if(this.next == null) then return 1;
+        else n = this.next.length(); return n + 1; end
     end
 end
 
 main
-    root := new Node(null, null, null, null, null, null);
-    tree := new Tree(root);
-    pair1 := new Pair(1,"a");
+    root = new Node(null, null, null, null, null, null);
+    tree = new Tree(root);
+    pair1 = new Pair(1,"a");
     tree.add(pair1);
-    i := 2;
+    i = 2;
     while( i <= 1 ) do
-    	pair2 := new Pair(i,"b");
+    	pair2 = new Pair(i,"b");
 	    tree.add(pair2);
-	    i := i + 1;
+	    i = i + 1;
     end
 
-    ww := new Wrap(tree, 1);
-    res := ww.lookup();
-    res := access("SELECT ?obj WHERE {?sth prog:Wrap_lookup_builtin_res ?obj}");
+    ww = new Wrap(tree, 1);
+    res = ww.lookup();
+    res = access("SELECT ?obj WHERE {?sth prog:Wrap_lookup_builtin_res ?obj}");
     print(res.content);
     print("done");
 end

--- a/examples/Cosim.smol
+++ b/examples/Cosim.smol
@@ -1,10 +1,10 @@
 main
     //beware: path is relative to interpreter instance, not this file
-    DE[Int integer_a, Int integer_b; Int integer_c] de := simulate("examples/adder.fmu", integer_a:=1, integer_b:=2);
-    Int i := de.integer_c;
+    DE[Int integer_a, Int integer_b; Int integer_c] de = simulate("examples/adder.fmu", integer_a=1, integer_b=2);
+    Int i = de.integer_c;
     print(i);
     de.tick(1);
-    de.integer_a := i;
-    i := de.integer_c;
+    de.integer_a = i;
+    i = de.integer_c;
     print(i);
 end

--- a/examples/Deprecated/OvenTwin/Connector.smol
+++ b/examples/Deprecated/OvenTwin/Connector.smol
@@ -6,7 +6,7 @@ class Connector(Boolean inAC, Boolean outAC) end
 class Installation(House house, Oven oven, Connector connector) 
     Boolean output()
         print(this.house.outlet.AC);
-        if(this.connector <> null) then
+        if(this.connector != null) then
             print(this.connector.inAC);
             print(this.connector.outAC);
         end
@@ -14,9 +14,9 @@ class Installation(House house, Oven oven, Connector connector)
         return False;
     end
     Int price() //simulate
-        Int res := 10;
-        if(this.connector.inAC) then res := res + 5; end
-        if(this.connector.outAC) then res := res + 5; end
+        Int res = 10;
+        if(this.connector.inAC) then res = res + 5; end
+        if(this.connector.outAC) then res = res + 5; end
         return res;
     end
 end
@@ -24,20 +24,20 @@ end
 
 class Constructor()
     House getHouse(Int id)
-        Boolean ac := False;
-        if( id >= 10 ) then ac := True; end
+        Boolean ac = False;
+        if( id >= 10 ) then ac = True; end
 
-        Outlet outlet_v := new Outlet(ac);
-        House house_v := new House(outlet_v);
+        Outlet outlet_v = new Outlet(ac);
+        House house_v = new House(outlet_v);
 
         return house_v;
     end
     Oven getOven(Int id)
-        Boolean ac := False;
-        if( id >= 10 ) then ac := True; end
+        Boolean ac = False;
+        if( id >= 10 ) then ac = True; end
 
-        Heater heater_v := new Heater(ac);
-        Oven oven_v := new Oven(heater_v);
+        Heater heater_v = new Heater(ac);
+        Oven oven_v = new Oven(heater_v);
 
         return oven_v;
     end
@@ -46,21 +46,21 @@ class Constructor()
 
 
         //Database access: Retrieve input
-        House house_v := this.getHouse(houseId);
-        Oven oven_v := this.getOven(ovenId);
+        House house_v = this.getHouse(houseId);
+        Oven oven_v = this.getOven(ovenId);
 
         //Schematics: Connect to partial input
-        Installation inst := new Installation(house_v, oven_v, null);
+        Installation inst = new Installation(house_v, oven_v, null);
 
 
         //Reasoning: Perform semantics to fill in gaps
-        Boolean fill := this.canFillIn(inst, True, True);
+        Boolean fill = this.canFillIn(inst, True, True);
         if(fill) then return inst; end
-        fill := this.canFillIn(inst, True, False);
+        fill = this.canFillIn(inst, True, False);
         if(fill) then return inst; end
-        fill := this.canFillIn(inst, False, True);
+        fill = this.canFillIn(inst, False, True);
         if(fill) then return inst; end
-        fill := this.canFillIn(inst, False, False);
+        fill = this.canFillIn(inst, False, False);
         if(fill) then  return inst; end
 
         //Error
@@ -68,23 +68,23 @@ class Constructor()
     end
 
     Boolean canFillIn(Installation inst, Boolean b1, Boolean b2)
-        List<Installation> list := null;
+        List<Installation> list = null;
         if(b1) then
-            if(b2) then list := access("SELECT ?obj WHERE {?obj a domain:ACACInst.}");
-            else list := access("SELECT ?obj WHERE {?obj a domain:ACDCInst.}");
+            if(b2) then list = access("SELECT ?obj WHERE {?obj a domain:ACACInst.}");
+            else list = access("SELECT ?obj WHERE {?obj a domain:ACDCInst.}");
             end
         else
-            if(b2) then list := access("SELECT ?obj WHERE {?obj a domain:DCACInst.}");
-            else list := access("SELECT ?obj WHERE {?obj a domain:DCDCInst.}");
+            if(b2) then list = access("SELECT ?obj WHERE {?obj a domain:DCACInst.}");
+            else list = access("SELECT ?obj WHERE {?obj a domain:DCDCInst.}");
             end
         end
-        //List<Installation> list :=
+        //List<Installation> list =
         //  access("SELECT ?obj WHERE {?obj prog:house ?x. ?x prog:outlet ?y. ?y prog:AC %1. ?obj prog:oven ?x2. ?x2 prog:heater ?y2. ?y2 prog:AC %2. }", b1, b2);
-        //List<Installation> list2 := member("<domain:ACACInst>"); //OWL bugged
-        if(list <> null) then
-            Boolean inside := list.contains(inst);
+        //List<Installation> list2 = member("<domain:ACACInst>"); //OWL bugged
+        if(list != null) then
+            Boolean inside = list.contains(inst);
             if(inside) then
-                inst.connector := new Connector(b1, b2);
+                inst.connector = new Connector(b1, b2);
                 return True;
             end
         end
@@ -93,11 +93,11 @@ class Constructor()
 end
 
 main
-    Constructor c := new Constructor();
-    Installation inst := c.fill(12, 11);
-    Int cost := inst.price();
+    Constructor c = new Constructor();
+    Installation inst = c.fill(12, 11);
+    Int cost = inst.price();
     print(cost);
-    Installation inst2 := c.fill(12, 1);
-    Int cost2 := inst2.price();
+    Installation inst2 = c.fill(12, 1);
+    Int cost2 = inst2.price();
     print(cost2);
 end

--- a/examples/Deprecated/geo.smol
+++ b/examples/Deprecated/geo.smol
@@ -14,22 +14,22 @@ end
 
 class LeftHydrocarbonMigration (GeoUnit gu)
     Int migrate()
-        GeoUnit started := this.gu;
-        Int b := 1;
-        while b = 1 do
-            b := this.gu.migrate();
+        GeoUnit started = this.gu;
+        Int b = 1;
+        while b == 1 do
+            b = this.gu.migrate();
         end
-        HoriTouch left := this.gu.left;
-        if left <> null then
+        HoriTouch left = this.gu.left;
+        if left != null then
             left.migrateLeft(this);
         end
-        if started <> this.gu then
+        if started != this.gu then
             this.migrate();
         end
         return 0;
     end
     LeftHydrocarbonMigration copy(GeoUnit param)
-        LeftHydrocarbonMigration c := new LeftHydrocarbonMigration(param);
+        LeftHydrocarbonMigration c = new LeftHydrocarbonMigration(param);
         return c;
     end
 end
@@ -37,8 +37,8 @@ end
 class <T> List(T content, List<T> next)
 
     Int append(List<T> last)
-        if this.next = null then
-            this.next := last;
+        if this.next == null then
+            this.next = last;
         else
             this.next.append(last);
         end
@@ -46,21 +46,21 @@ class <T> List(T content, List<T> next)
     end
 
     T get(Int i)
-        T res := this.content;
+        T res = this.content;
         if i >= 1 then
-            res := this.next.get(i-1);
+            res = this.next.get(i-1);
         end
         return res;
     end
 
     Int contains(T element)
-        if this.content = element then
+        if this.content == element then
             return 1;
         else
-            if this.next = null then
+            if this.next == null then
                 return 0;
             else
-                Int res := this.next.contains(element);
+                Int res = this.next.contains(element);
                 return res;
             end
         end
@@ -69,33 +69,33 @@ end
 
 class GeoManager (List<GeoUnit> list)
     GeoUnit createNew(Int seal)
-        GeoUnit tmp := new GeoUnit(seal, null, null, null, null, null);
-        this.list := new List<GeoUnit>(tmp, this.list);
+        GeoUnit tmp = new GeoUnit(seal, null, null, null, null, null);
+        this.list = new List<GeoUnit>(tmp, this.list);
         return tmp;
     end
 
     Int connectLR(GeoUnit g1, GeoUnit g2)
-        HoriTouch cn1 := new HoriTouch(0, null, g1, g2);
-        g1.right := cn1;
-        g2.left := cn1;
+        HoriTouch cn1 = new HoriTouch(0, null, g1, g2);
+        g1.right = cn1;
+        g2.left = cn1;
         return 0;
     end
 
 
     Int connectTB(GeoUnit g1, GeoUnit g2)
-        VertTouch cn1 := new VertTouch(0, null, g1, g2);
-        g1.bottom := cn1;
-        g2.top := cn1;
+        VertTouch cn1 = new VertTouch(0, null, g1, g2);
+        g1.bottom = cn1;
+        g2.top = cn1;
         return 0;
     end
 
     Int startEarthquake(Int sealing, GeoUnit gu)
-        Int known := this.list.contains(gu);
-        if known = 1 then
-            while gu.top <> null do
-                gu := gu.top.s1;
+        Int known = this.list.contains(gu);
+        if known == 1 then
+            while gu.top != null do
+                gu = gu.top.s1;
             end
-            Fault fault := new Fault(sealing, null, null, null);
+            Fault fault = new Fault(sealing, null, null, null);
             gu.earthquake(fault);
             return 0;
         else return 0; end
@@ -106,9 +106,9 @@ end
 
 class GeoUnit extends GeoElement (VertTouch top, HoriTouch left, HoriTouch right, VertTouch bottom)
     Int earthquake(Fault fault)
-        if this.right <> null then
+        if this.right != null then
             fault.replaces(this.right);
-            if this.bottom <> null then
+            if this.bottom != null then
                 this.bottom.s2.earthquake(fault);
             end
         end
@@ -116,12 +116,12 @@ class GeoUnit extends GeoElement (VertTouch top, HoriTouch left, HoriTouch right
     end
 
     Int migrate()
-        if this.top <> null then
-            if this.top.s1.sealing <> 1 then
-                GeoUnit old := this.migration.gu;
-                this.top.s1.migration := this.migration;
-                this.migration.gu := this.top.s1;
-                old.migration := null;
+        if this.top != null then
+            if this.top.s1.sealing != 1 then
+                GeoUnit old = this.migration.gu;
+                this.top.s1.migration = this.migration;
+                this.migration.gu = this.top.s1;
+                old.migration = null;
                 return 1;
             end
         end
@@ -129,12 +129,12 @@ class GeoUnit extends GeoElement (VertTouch top, HoriTouch left, HoriTouch right
     end
 
     GeoUnit getTopNonSealing()
-        if this.sealing <> 1 then
+        if this.sealing != 1 then
             return this;
         else
-            if this.top <> null then
-                GeoUnit target := this.top.s1;
-                GeoUnit res := target.getTopNonSealing();
+            if this.top != null then
+                GeoUnit target = this.top.s1;
+                GeoUnit res = target.getTopNonSealing();
                 return res;
             else return this; end
         end
@@ -143,12 +143,12 @@ end
 
 class HoriTouch extends GeoElement (GeoElement s1, GeoElement s2)
     Int migrateLeft(LeftHydrocarbonMigration mig)
-        if this.s1.sealing <> 1 then
-            if this.s1.migration = null then
-                GeoUnit old := mig.gu;
-                this.s1.migration := mig;
-                mig.gu := this.s1;
-                old.migration := null;
+        if this.s1.sealing != 1 then
+            if this.s1.migration == null then
+                GeoUnit old = mig.gu;
+                this.s1.migration = mig;
+                mig.gu = this.s1;
+                old.migration = null;
                 return 1;
             end
         end
@@ -160,29 +160,29 @@ class VertTouch extends GeoElement (GeoUnit s1, GeoUnit s2) end
 
 class Fault extends GeoElement (List<GeoUnit> s1, List<GeoUnit> s2)
     Int replaces(HoriTouch touch)
-        touch.s1.right := this; //XXX
-        touch.s2.left  := this; //XXX
-        this.s1 := new List<GeoElement>(touch.s1, this.s1);
-        this.s2 := new List<GeoElement>(touch.s2, this.s2);
+        touch.s1.right = this; //XXX
+        touch.s2.left  = this; //XXX
+        this.s1 = new List<GeoElement>(touch.s1, this.s1);
+        this.s2 = new List<GeoElement>(touch.s2, this.s2);
         return 0;
     end
 
     Int migrateLeft(LeftHydrocarbonMigration mig)
-        if this.sealing <> 1 then
-            if this.s1 <> null then
-                List<GeoUnit> currentLeft := this.s1;
-                List<GeoUnit> currentRight := this.s2;
-                while currentRight.content <> mig.gu do
-                    currentLeft := currentLeft.next;
-                    currentRight := currentRight.next;
+        if this.sealing != 1 then
+            if this.s1 != null then
+                List<GeoUnit> currentLeft = this.s1;
+                List<GeoUnit> currentRight = this.s2;
+                while currentRight.content != mig.gu do
+                    currentLeft = currentLeft.next;
+                    currentRight = currentRight.next;
                 end
-                GeoUnit finalLeft := currentLeft.content.getTopNonSealing();
-                if finalLeft.sealing <> 1 then
-                    if finalLeft.migration = null then
-                        GeoUnit old := mig.gu;
-                        finalLeft.migration := mig;
-                        mig.gu := finalLeft;
-                        old.migration := null;
+                GeoUnit finalLeft = currentLeft.content.getTopNonSealing();
+                if finalLeft.sealing != 1 then
+                    if finalLeft.migration == null then
+                        GeoUnit old = mig.gu;
+                        finalLeft.migration = mig;
+                        mig.gu = finalLeft;
+                        old.migration = null;
                         return 1;
                    end
                 end
@@ -194,16 +194,16 @@ end
 
 
 main
-    GeoUnit gu11 := new GeoUnit(1, null, null, null, null, null);
-    List<GeoUnit> initList := new List<GeoUnit>(gu11, null);
-    GeoManager manager := new GeoManager(initList);
+    GeoUnit gu11 = new GeoUnit(1, null, null, null, null, null);
+    List<GeoUnit> initList = new List<GeoUnit>(gu11, null);
+    GeoManager manager = new GeoManager(initList);
 
 
 
-    GeoUnit gu12 := manager.createNew(1);
-    GeoUnit gu13 := manager.createNew(1);
-    GeoUnit gu14 := manager.createNew(1);
-    GeoUnit gu15 := manager.createNew(1);
+    GeoUnit gu12 = manager.createNew(1);
+    GeoUnit gu13 = manager.createNew(1);
+    GeoUnit gu14 = manager.createNew(1);
+    GeoUnit gu15 = manager.createNew(1);
     manager.connectLR(gu11, gu12);
     manager.connectLR(gu12, gu13);
     manager.connectLR(gu13, gu14);
@@ -211,11 +211,11 @@ main
 
     print("1:-XX|XX-");
 
-    GeoUnit gu21 := manager.createNew(1);
-    GeoUnit gu22 := manager.createNew(0);
-    GeoUnit gu23 := manager.createNew(1);
-    GeoUnit gu24 := manager.createNew(0);
-    GeoUnit gu25 := manager.createNew(1);
+    GeoUnit gu21 = manager.createNew(1);
+    GeoUnit gu22 = manager.createNew(0);
+    GeoUnit gu23 = manager.createNew(1);
+    GeoUnit gu24 = manager.createNew(0);
+    GeoUnit gu25 = manager.createNew(1);
     manager.connectTB(gu11, gu21);
     manager.connectTB(gu12, gu22);
     manager.connectTB(gu13, gu23);
@@ -228,11 +228,11 @@ main
 
     print("2:X X| X-");
 
-    GeoUnit gu31 := manager.createNew(1);
-    GeoUnit gu32 := manager.createNew(0);
-    GeoUnit gu33 := manager.createNew(0);
-    GeoUnit gu34 := manager.createNew(1);
-    GeoUnit gu35 := manager.createNew(1);
+    GeoUnit gu31 = manager.createNew(1);
+    GeoUnit gu32 = manager.createNew(0);
+    GeoUnit gu33 = manager.createNew(0);
+    GeoUnit gu34 = manager.createNew(1);
+    GeoUnit gu35 = manager.createNew(1);
     manager.connectTB(gu21, gu31);
     manager.connectTB(gu22, gu32);
     manager.connectTB(gu23, gu33);
@@ -245,12 +245,12 @@ main
 
     print("3:X  |XX-");
 
-    GeoUnit gu41 := manager.createNew(1);
-    GeoUnit gu42 := manager.createNew(1);
-    GeoUnit gu43 := manager.createNew(1);
-    GeoUnit gu44 := manager.createNew(1);
-    GeoUnit gu45 := manager.createNew(1);
-    GeoUnit gu46 := manager.createNew(1);
+    GeoUnit gu41 = manager.createNew(1);
+    GeoUnit gu42 = manager.createNew(1);
+    GeoUnit gu43 = manager.createNew(1);
+    GeoUnit gu44 = manager.createNew(1);
+    GeoUnit gu45 = manager.createNew(1);
+    GeoUnit gu46 = manager.createNew(1);
 
     manager.connectTB(gu31, gu41);
     manager.connectTB(gu32, gu42);
@@ -266,10 +266,10 @@ main
 
     print("4:XXX|XXX");
 
-    GeoUnit gu53 := manager.createNew(1);
-    GeoUnit gu54 := manager.createNew(0);
-    GeoUnit gu55 := manager.createNew(0);
-    GeoUnit gu56 := manager.createNew(1);
+    GeoUnit gu53 = manager.createNew(1);
+    GeoUnit gu54 = manager.createNew(0);
+    GeoUnit gu55 = manager.createNew(0);
+    GeoUnit gu56 = manager.createNew(1);
     manager.connectTB(gu43, gu53);
     manager.connectTB(gu44, gu54);
     manager.connectTB(gu45, gu55);
@@ -280,10 +280,10 @@ main
 
     print("5:--X|  X");
 
-    GeoUnit gu63 := manager.createNew(1);
-    GeoUnit gu64 := manager.createNew(1);
-    GeoUnit gu65 := manager.createNew(1);
-    GeoUnit gu66 := manager.createNew(1);
+    GeoUnit gu63 = manager.createNew(1);
+    GeoUnit gu64 = manager.createNew(1);
+    GeoUnit gu65 = manager.createNew(1);
+    GeoUnit gu66 = manager.createNew(1);
     manager.connectTB(gu53, gu63);
     manager.connectTB(gu54, gu64);
     manager.connectTB(gu55, gu65);
@@ -297,12 +297,12 @@ main
 
     manager.startEarthquake(0, gu63);
 
-    LeftHydrocarbonMigration mig := new LeftHydrocarbonMigration(gu55);
-    gu55.migration := mig;
+    LeftHydrocarbonMigration mig = new LeftHydrocarbonMigration(gu55);
+    gu55.migration = mig;
 
     //instead of mig.migrate(); we use ontology-based reflexion
-    List<LeftHydrocarbonMigration> all := access("SELECT ?obj WHERE {?obj a prog:LeftHydrocarbonMigration }");
+    List<LeftHydrocarbonMigration> all = access("SELECT ?obj WHERE {?obj a prog:LeftHydrocarbonMigration }");
     all.content.migrate();
-    List<Object> nulls := access("SELECT ?obj WHERE { ?obj a :HasAnyNullNext }");
+    List<Object> nulls = access("SELECT ?obj WHERE { ?obj a :HasAnyNullNext }");
     print(nulls);
 end

--- a/examples/House/osphouse.smol
+++ b/examples/House/osphouse.smol
@@ -12,14 +12,14 @@ class Room extends Dynamic(Cont[in Double h_InnerWall, in Double h_OuterWall, in
                            Controller ctrl,
                            Boolean isFirst)
     override Int propagate()
-            Double hIn := this.inner.getH();
-            this.dynamics.h_InnerWall := hIn;
-            Double hOut := this.outer.getH();
-            this.dynamics.h_OuterWall := hOut;
+            Double hIn = this.inner.getH();
+            this.dynamics.h_InnerWall = hIn;
+            Double hOut = this.outer.getH();
+            this.dynamics.h_OuterWall = hOut;
             if(this.isFirst) then
-                this.dynamics.h_powerHeater := this.ctrl.dynamics.h_room1;
+                this.dynamics.h_powerHeater = this.ctrl.dynamics.h_room1;
             else
-                this.dynamics.h_powerHeater := this.ctrl.dynamics.h_room2;
+                this.dynamics.h_powerHeater = this.ctrl.dynamics.h_room2;
             end
         return 0;
     end
@@ -33,9 +33,9 @@ class Controller extends Dynamic(Cont[in Double T_room1, in Double T_room2, in D
                                  Room r1,
                                  Room r2)
     override Int propagate()
-            this.dynamics.T_room1 := this.r1.dynamics.T_room;
-            this.dynamics.T_room2 := this.r2.dynamics.T_room;
-            this.dynamics.T_clock := this.clock.Clock;
+            this.dynamics.T_room1 = this.r1.dynamics.T_room;
+            this.dynamics.T_room2 = this.r2.dynamics.T_room;
+            this.dynamics.T_clock = this.clock.Clock;
             return 0;
     end
     override Int advance(Double db)
@@ -46,8 +46,8 @@ class Controller extends Dynamic(Cont[in Double T_room1, in Double T_room2, in D
 end
 class InnerWall extends Wall(Cont[in Double T_room1, in Double T_room2, out Double h_wall] dynamics, Room left, Room right)
     override Int propagate()
-            this.dynamics.T_room1   := this.left.dynamics.T_room;
-            this.dynamics.T_room2   := this.right.dynamics.T_room;
+            this.dynamics.T_room1   = this.left.dynamics.T_room;
+            this.dynamics.T_room2   = this.right.dynamics.T_room;
             return 0;
     end
     override Int advance(Double db)
@@ -60,8 +60,8 @@ class InnerWall extends Wall(Cont[in Double T_room1, in Double T_room2, out Doub
 end
 class OuterWall1 extends Wall(Cont[in Double T_room1, in Double T_outside, out Double h_wall] dynamics, Room inner, Outside outside)
     override Int propagate()
-            this.dynamics.T_room1   := this.inner.dynamics.T_room;
-            this.dynamics.T_outside := this.outside.temp;
+            this.dynamics.T_room1   = this.inner.dynamics.T_room;
+            this.dynamics.T_outside = this.outside.temp;
             return 0;
     end
     override Double getH()
@@ -74,8 +74,8 @@ class OuterWall1 extends Wall(Cont[in Double T_room1, in Double T_outside, out D
 end
 class OuterWall2 extends Wall(Cont[in Double T_room2, in Double T_outside, out Double h_wall] dynamics, Room inner, Outside outside)
     override Int propagate()
-            this.dynamics.T_room2   := this.inner.dynamics.T_room;
-            this.dynamics.T_outside := this.outside.temp;
+            this.dynamics.T_room2   = this.inner.dynamics.T_room;
+            this.dynamics.T_outside = this.outside.temp;
             return 0;
     end
     override Double getH()
@@ -88,37 +88,37 @@ class OuterWall2 extends Wall(Cont[in Double T_room2, in Double T_outside, out D
 end
 
 main
-    Cont[in Double T_room1, in Double T_room2, out Double h_wall] i := simulate("examples\House\fmus\InnerWall.fmu");
-    Cont[in Double T_room1, in Double T_outside, out Double h_wall] o1 := simulate("examples\House\fmus\OuterWall1.fmu");
-    Cont[in Double T_room2, in Double T_outside, out Double h_wall] o2 := simulate("examples\House\fmus\OuterWall2.fmu");
-    Cont[in Double h_InnerWall, in Double h_OuterWall, in Double h_powerHeater, out Double T_room] r1 := simulate("examples\House\fmus\Room1.fmu");
-    r1.role := "room1";
-    Cont[in Double h_InnerWall, in Double h_OuterWall, in Double h_powerHeater, out Double T_room] r2 := simulate("examples\House\fmus\Room2.fmu");
-    r2.role := "room2";
-    Cont[in Double T_room1, in Double T_room2, in Double T_clock, out Double h_room1, out Double h_room2] ctrl := simulate("examples\House\fmus\TempController.fmu");
-    Cont[out Double Clock] cl := simulate("examples\House\fmus\Clock.fmu", Reset := 100);
+    Cont[in Double T_room1, in Double T_room2, out Double h_wall] i = simulate("examples\House\fmus\InnerWall.fmu");
+    Cont[in Double T_room1, in Double T_outside, out Double h_wall] o1 = simulate("examples\House\fmus\OuterWall1.fmu");
+    Cont[in Double T_room2, in Double T_outside, out Double h_wall] o2 = simulate("examples\House\fmus\OuterWall2.fmu");
+    Cont[in Double h_InnerWall, in Double h_OuterWall, in Double h_powerHeater, out Double T_room] r1 = simulate("examples\House\fmus\Room1.fmu");
+    r1.role = "room1";
+    Cont[in Double h_InnerWall, in Double h_OuterWall, in Double h_powerHeater, out Double T_room] r2 = simulate("examples\House\fmus\Room2.fmu");
+    r2.role = "room2";
+    Cont[in Double T_room1, in Double T_room2, in Double T_clock, out Double h_room1, out Double h_room2] ctrl = simulate("examples\House\fmus\TempController.fmu");
+    Cont[out Double Clock] cl = simulate("examples\House\fmus\Clock.fmu", Reset = 100);
 
 
-    Outside outside1 := new Outside(5.3);
-    Outside outside2 := new Outside(4.9);
-    Room room1 := new Room(r1, null, null, null, True);
-    Room room2 := new Room(r2, null, null, null, False);
-    Wall inner  := new InnerWall(i, room1, room2);
-    Wall outer1 := new OuterWall1(o1, room1, outside1);
-    Wall outer2 := new OuterWall2(o2, room2, outside2);
-    Controller control := new Controller(ctrl, cl, room1, room2);
-    room1.ctrl := control;
-    room1.inner := inner;
-    room1.outer := outer1;
-    room2.ctrl := control;
-    room2.inner := inner;
-    room2.outer := outer2;
-    Boolean b := validate("examples\House\shape.ttl");
+    Outside outside1 = new Outside(5.3);
+    Outside outside2 = new Outside(4.9);
+    Room room1 = new Room(r1, null, null, null, True);
+    Room room2 = new Room(r2, null, null, null, False);
+    Wall inner  = new InnerWall(i, room1, room2);
+    Wall outer1 = new OuterWall1(o1, room1, outside1);
+    Wall outer2 = new OuterWall2(o2, room2, outside2);
+    Controller control = new Controller(ctrl, cl, room1, room2);
+    room1.ctrl = control;
+    room1.inner = inner;
+    room1.outer = outer1;
+    room2.ctrl = control;
+    room2.inner = inner;
+    room2.outer = outer2;
+    Boolean b = validate("examples\House\shape.ttl");
     print(b);
 
-    Double step := 0.01;
-    Int at := 0;
-    Int limit := 60000;
+    Double step = 0.01;
+    Int at = 0;
+    Int limit = 60000;
 
     while at < limit do
         room1.propagate();
@@ -135,8 +135,8 @@ main
         inner.advance(step);
         control.advance(step);
 
-        at := at + 1;
-        if(at % 100 = 0) then print(room2.dynamics.T_room); end
+        at = at + 1;
+        if(at % 100 == 0) then print(room2.dynamics.T_room); end
     end
 
 end

--- a/examples/Orchestrate/Gauss.smol
+++ b/examples/Orchestrate/Gauss.smol
@@ -15,7 +15,7 @@ end
 
 class ImplConnection extends Connection (OutPort<Double> from, InPort<Double> to)
     override Int propagate()
-        Double val := this.from.get();
+        Double val = this.from.get();
         this.to.write(val);
         return 0;
     end
@@ -24,25 +24,25 @@ end
 //Gauss master algorithm: propagate through all FMUs, advance time for all FMUs at once
 class CoSim(List<Connection> list, List<Cont[]> sims, Double stepSize)
     Int round()
-        Int i := 0;
-        if this.list = null then return i; end
-        if this.sims = null then return i; end
-        Int length := this.list.length();
+        Int i = 0;
+        if this.list == null then return i; end
+        if this.sims == null then return i; end
+        Int length = this.list.length();
         while i < length do
-            Connection c := this.list.get(i);
+            Connection c = this.list.get(i);
             c.propagate();
-            Cont[] de := this.sims.get(i); //note: we do check here that we do not advance twice if an FMU has two output connections
+            Cont[] de = this.sims.get(i); //note: we do check here that we do not advance twice if an FMU has two output connections
             de.tick(this.stepSize);
-            i := i+1;
+            i = i+1;
         end
         return i;
     end
 
     Int execute(Int steps)
-        Int i := 1;
+        Int i = 1;
         while( i <= steps ) do
             this.round();
-            i := i+1;
+            i = i+1;
         end
         return i;
     end
@@ -56,32 +56,32 @@ class PredatorOutPort extends OutPort<Double>(Cont[in Double x, out Double y] y)
     override Double get() return this.y.y; end
 end
 class PreyInPort extends InPort<Double>(Cont[in Double y, out Double x] y)
-    override Boolean write(Double t) this.y.y := t; return True; end
+    override Boolean write(Double t) this.y.y = t; return True; end
 end
 class PredatorInPort extends InPort<Double>(Cont[in Double x, out Double y] x)
-    override Boolean write(Double t) print(t); this.x.x := t; return True; end
+    override Boolean write(Double t) print(t); this.x.x = t; return True; end
 end
 
 main
-    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
-    PreyOutPort preyOut := new PreyOutPort(prey);
-    PredatorOutPort predOut := new PredatorOutPort(predator);
-    PreyInPort preyIn := new PreyInPort(prey);
-    PredatorInPort predIn := new PredatorInPort(predator);
-    Connection c1 := new ImplConnection(preyOut, predIn);
-    Connection c2 := new ImplConnection(predOut, preyIn);
-    List<Cont[]> fmus := new List<Cont[]>(prey, null);
-    fmus := new List<Cont[]>(predator, fmus);
-    List<Connection> cons := new List<Connection>(c1, null);
-    cons := new List<Connection>(c2, cons);
-    CoSim sim := new CoSim(cons, fmus, 0.05);
+    Cont[in Double y, out Double x] prey = simulate("examples/SimulationDemo/Prey.fmu", y = 10);
+    Cont[in Double x, out Double y] predator = simulate("examples/SimulationDemo/Predator.fmu", x = 10);
+    PreyOutPort preyOut = new PreyOutPort(prey);
+    PredatorOutPort predOut = new PredatorOutPort(predator);
+    PreyInPort preyIn = new PreyInPort(prey);
+    PredatorInPort predIn = new PredatorInPort(predator);
+    Connection c1 = new ImplConnection(preyOut, predIn);
+    Connection c2 = new ImplConnection(predOut, preyIn);
+    List<Cont[]> fmus = new List<Cont[]>(prey, null);
+    fmus = new List<Cont[]>(predator, fmus);
+    List<Connection> cons = new List<Connection>(c1, null);
+    cons = new List<Connection>(c2, cons);
+    CoSim sim = new CoSim(cons, fmus, 0.05);
     sim.execute(4000);
 
-    List<InPort<Double>> ll := access("SELECT ?obj WHERE {?con a prog:ImplConnection. ?con prog:ImplConnection_to ?obj}");
-    while ll <> null do
-        InPort<Double> inp := ll.content;
-        ll := ll.next;
+    List<InPort<Double>> ll = access("SELECT ?obj WHERE {?con a prog:ImplConnection. ?con prog:ImplConnection_to ?obj}");
+    while ll != null do
+        InPort<Double> inp = ll.content;
+        ll = ll.next;
         print(inp);
     end
 end

--- a/examples/Orchestrate/Jacobi.smol
+++ b/examples/Orchestrate/Jacobi.smol
@@ -16,7 +16,7 @@ end
 
 class ImplConnection extends Connection (OutPort<Double> from, InPort<Double> to)
     override Int propagate()
-        Double val := this.from.get();
+        Double val = this.from.get();
         this.to.write(val);
         return 0;
     end
@@ -25,30 +25,30 @@ end
 //Jacobi master algorithm: propagate through all connections, advance time for all FMUs at once
 class CoSim(List<Connection> list, List<Cont[]> sims, Double stepSize)
     Int round()
-        Int i := 0;
-        if this.list = null then return i; end
-        Int length := this.list.length();
+        Int i = 0;
+        if this.list == null then return i; end
+        Int length = this.list.length();
         while i < length do
-            Connection c := this.list.get(i);
+            Connection c = this.list.get(i);
             c.propagate();
-            i := i+1;
+            i = i+1;
         end
-        i := 0;
-        if this.sims = null then return i; end
-        length := this.sims.length();
+        i = 0;
+        if this.sims == null then return i; end
+        length = this.sims.length();
         while i < length do
-            Cont[] de := this.sims.get(i);
+            Cont[] de = this.sims.get(i);
             de.tick(this.stepSize);
-            i := i + 1;
+            i = i + 1;
         end
         return i;
     end
 
     Int execute(Int steps)
-        Int i := 1;
+        Int i = 1;
         while( i <= steps ) do
             this.round();
-            i := i+1;
+            i = i+1;
         end
         return i;
     end
@@ -62,32 +62,32 @@ class PredatorOutPort extends OutPort<Double>(Cont[in Double x, out Double y] y)
     override Double get() return this.y.y; end
 end
 class PreyInPort extends InPort<Double>(Cont[in Double y, out Double x] y)
-    override Boolean write(Double t) this.y.y := t; return True; end
+    override Boolean write(Double t) this.y.y = t; return True; end
 end
 class PredatorInPort extends InPort<Double>(Cont[in Double x, out Double y] x)
-    override Boolean write(Double t) print(t); this.x.x := t; return True; end
+    override Boolean write(Double t) print(t); this.x.x = t; return True; end
 end
 
 main
-    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
-    PreyOutPort preyOut := new PreyOutPort(prey);
-    PredatorOutPort predOut := new PredatorOutPort(predator);
-    PreyInPort preyIn := new PreyInPort(prey);
-    PredatorInPort predIn := new PredatorInPort(predator);
-    Connection c1 := new ImplConnection(preyOut, predIn);
-    Connection c2 := new ImplConnection(predOut, preyIn);
-    List<Cont[]> fmus := new List<Cont[]>(prey, null);
-    fmus := new List<Cont[]>(predator, fmus);
-    List<Connection> cons := new List<Connection>(c1, null);
-    cons := new List<Connection>(c2, cons);
-    CoSim sim := new CoSim(cons, fmus, 0.01);
+    Cont[in Double y, out Double x] prey = simulate("examples/SimulationDemo/Prey.fmu", y = 10);
+    Cont[in Double x, out Double y] predator = simulate("examples/SimulationDemo/Predator.fmu", x = 10);
+    PreyOutPort preyOut = new PreyOutPort(prey);
+    PredatorOutPort predOut = new PredatorOutPort(predator);
+    PreyInPort preyIn = new PreyInPort(prey);
+    PredatorInPort predIn = new PredatorInPort(predator);
+    Connection c1 = new ImplConnection(preyOut, predIn);
+    Connection c2 = new ImplConnection(predOut, preyIn);
+    List<Cont[]> fmus = new List<Cont[]>(prey, null);
+    fmus = new List<Cont[]>(predator, fmus);
+    List<Connection> cons = new List<Connection>(c1, null);
+    cons = new List<Connection>(c2, cons);
+    CoSim sim = new CoSim(cons, fmus, 0.01);
     sim.execute(20000);
 
-    List<InPort<Double>> ll := access("SELECT ?obj WHERE {?con a prog:ImplConnection. ?con prog:ImplConnection_to ?obj}");
-    while ll <> null do
-        InPort<Double> inp := ll.content;
-        ll := ll.next;
+    List<InPort<Double>> ll = access("SELECT ?obj WHERE {?con a prog:ImplConnection. ?con prog:ImplConnection_to ?obj}");
+    while ll != null do
+        InPort<Double> inp = ll.content;
+        ll = ll.next;
         print(inp);
     end
 end

--- a/examples/Shadow/detect.smol
+++ b/examples/Shadow/detect.smol
@@ -2,48 +2,48 @@ class Shadow(Double value, Double assumedSlope)
 
     Cont[out Double value] findNewShadow(Double lastVal, Double sysVal)
         print("Anomaly detected, searching for new shadow.");
-        Double step := 0.0;
-        Cont[out Double value] shadow := null;
+        Double step = 0.0;
+        Cont[out Double value] shadow = null;
         while step <= 5 do
-            Double assumedSlope := this.assumedSlope + step * 0.2;
-            shadow := simulate("examples/Shadow/Sim.fmu", iValue := lastVal, slope := assumedSlope);
+            Double assumedSlope = this.assumedSlope + step * 0.2;
+            shadow = simulate("examples/Shadow/Sim.fmu", iValue = lastVal, slope = assumedSlope);
             shadow.tick(1.0);
-            Double result := shadow.value;
-            Double diff := sysVal - result;
+            Double result = shadow.value;
+            Double diff = sysVal - result;
             if(diff <= 0.1) then
                 print("New shadow found.");
                 return shadow;
             end
-            step := step + 1.0;
+            step = step + 1.0;
         end
         print("No new shadow found.");
         return null;
     end
 
     Int run()
-        Cont[out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := this.value, slope := this.assumedSlope);
-        Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
+        Cont[out Double value] system = simulate("examples/Shadow/Realsys.fmu", iValue = this.value, slope = this.assumedSlope);
+        Cont[out Double value] shadow = simulate("examples/Shadow/Sim.fmu", iValue = this.value, slope = this.assumedSlope);
 
-        Int i := 0;
-        Double lastDiff := 0.0;
-        Double lastVal := 2.0;
+        Int i = 0;
+        Double lastDiff = 0.0;
+        Double lastVal = 2.0;
         while i <= 200 do
-            lastVal := system.value;
+            lastVal = system.value;
             system.tick(1.0);
             shadow.tick(1.0);
-            Double sysVal := system.value;
-            Double shaVal := shadow.value;
-            Double diff := system.value - shadow.value;
+            Double sysVal = system.value;
+            Double shaVal = shadow.value;
+            Double diff = system.value - shadow.value;
             if(diff >= 0.1) then
-                shadow := this.findNewShadow(lastVal, sysVal);
+                shadow = this.findNewShadow(lastVal, sysVal);
             end
-            i := i + 1;
+            i = i + 1;
         end
         return i;
     end
 end
 
 main
-    Shadow shadow := new Shadow(2.0, 1.0);
+    Shadow shadow = new Shadow(2.0, 1.0);
     shadow.run();
 end

--- a/examples/Shadow/series.smol
+++ b/examples/Shadow/series.smol
@@ -1,31 +1,31 @@
 //requires length > 0 && content == null
 class Buffer(Int length, List<Double> content)
     Unit init()
-        Int i := 0;
-        this.content := null;
+        Int i = 0;
+        this.content = null;
         while i < this.length  do
-            this.content := new List<Double>(0.0, this.content);
-            i := i + 1;
+            this.content = new List<Double>(0.0, this.content);
+            i = i + 1;
         end
     end
     Unit add(Double d)
-        List<Double> next := new List<Double>(d, null);
+        List<Double> next = new List<Double>(d, null);
         this.content.append(next);
-        this.content := this.content.next;
+        this.content = this.content.next;
     end
 
     //requires other.length == this.length && other != null
     Double distance(Buffer other)
-        Int i := 0;
-        Double sum := 0.0;
-        List<Double> mine := this.content;
-        List<Double> theirs := other.content;
+        Int i = 0;
+        Double sum = 0.0;
+        List<Double> mine = this.content;
+        List<Double> theirs = other.content;
         while i < this.length  do
-            Double local := mine.content - theirs.content;
-            sum := sum + local*local;
-            mine := mine.next;
-            theirs := theirs.next;
-            i := i + 1;
+            Double local = mine.content - theirs.content;
+            sum = sum + local*local;
+            mine = mine.next;
+            theirs = theirs.next;
+            i = i + 1;
         end
         return sum/i;
     end
@@ -36,16 +36,16 @@ class ExplorationShadow(Double value, Double assumedSlope, Buffer buffer)
 
     //requires record != null
     Double runAndCompare(Int l, Buffer record)
-        this.buffer := new Buffer(l, null);
+        this.buffer = new Buffer(l, null);
         this.buffer.init();
-        Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
-        Int i := 0;
+        Cont[out Double value] shadow = simulate("examples/Shadow/Sim.fmu", iValue = this.value, slope = this.assumedSlope);
+        Int i = 0;
         while i < l do
             this.buffer.add(shadow.value);
             shadow.tick(1.0);
-            i := i + 1;
+            i = i + 1;
         end
-        Double error := record.distance(this.buffer);
+        Double error = record.distance(this.buffer);
         return error;
     end
 end
@@ -54,55 +54,55 @@ end
 class MonitorShadow(Cont[out Double value] system, Double value, Double assumedSlope, Buffer bufferSystem, Buffer bufferShadow, Int limit, Int recordLength)
     Unit run()
         print("Start");
-        Int step := 0;
-        Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := this.value, slope := this.assumedSlope);
-        this.bufferSystem := new Buffer(this.recordLength, null);
+        Int step = 0;
+        Cont[out Double value] shadow = simulate("examples/Shadow/Sim.fmu", iValue = this.value, slope = this.assumedSlope);
+        this.bufferSystem = new Buffer(this.recordLength, null);
         this.bufferSystem.init();
         this.bufferSystem.add(this.system.value);
-        this.bufferShadow := new Buffer(this.recordLength, null);
+        this.bufferShadow = new Buffer(this.recordLength, null);
         this.bufferShadow.init();
         this.bufferShadow.add(shadow.value);
 
-        Int sinceReset := 0;
+        Int sinceReset = 0;
         while step < this.limit do
             this.system.tick(1.0);
             shadow.tick(1.0);
             this.bufferSystem.add(this.system.value);
             this.bufferShadow.add(shadow.value);
-            Double error := this.bufferSystem.distance(this.bufferShadow);
+            Double error = this.bufferSystem.distance(this.bufferShadow);
             if error > 10.0 & sinceReset >= this.recordLength*2 then
                 print("error");
                 print(error);
                 print("at");
                 print(step);
-                this.bufferShadow := new Buffer(this.recordLength, null);
+                this.bufferShadow = new Buffer(this.recordLength, null);
                 this.bufferShadow.init();
-                shadow := this.findNewShadow();
-                sinceReset := 0;
+                shadow = this.findNewShadow();
+                sinceReset = 0;
             end
-            sinceReset := sinceReset + 1;
-            step := step + 1;
+            sinceReset = sinceReset + 1;
+            step = step + 1;
         end
         print("End");
     end
 
     Cont[out Double value] findNewShadow()
         print("Anomaly detected, searching for new shadow.");
-        Double step := 0.0;
-        ExplorationShadow explore := null;
+        Double step = 0.0;
+        ExplorationShadow explore = null;
         while step <= 5 do
-            Double mySlope := this.assumedSlope + step * 0.2;
-            explore := new ExplorationShadow(this.bufferSystem.content.content, mySlope, null);
-            Double diff := explore.runAndCompare(this.recordLength, this.bufferSystem);
+            Double mySlope = this.assumedSlope + step * 0.2;
+            explore = new ExplorationShadow(this.bufferSystem.content.content, mySlope, null);
+            Double diff = explore.runAndCompare(this.recordLength, this.bufferSystem);
             if diff <= 0.01 then
                 print("New shadow found.");
                 print(diff);
                 print(mySlope);
-                Double toStart := this.bufferSystem.content.last();
-                Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := toStart, slope := mySlope);
+                Double toStart = this.bufferSystem.content.last();
+                Cont[out Double value] shadow = simulate("examples/Shadow/Sim.fmu", iValue = toStart, slope = mySlope);
                 return shadow;
             end
-            step := step + 1.0;
+            step = step + 1.0;
         end
         print("No new shadow found.");
         return null;
@@ -110,7 +110,7 @@ class MonitorShadow(Cont[out Double value] system, Double value, Double assumedS
 end
 
 main
-    Cont[out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2.0, slope := 1.0);
-    MonitorShadow monitor := new MonitorShadow(system, 2.0, 1.0, null, null, 200, 3);
+    Cont[out Double value] system = simulate("examples/Shadow/Realsys.fmu", iValue = 2.0, slope = 1.0);
+    MonitorShadow monitor = new MonitorShadow(system, 2.0, 1.0, null, null, 200, 3);
     monitor.run();
 end

--- a/examples/Shadow/shadow.smol
+++ b/examples/Shadow/shadow.smol
@@ -1,16 +1,16 @@
 main
 
-    Cont[out Double value] system := simulate("examples/Shadow/Realsys.fmu", iValue := 2, slope := 1);
-    Cont[out Double value] shadow := simulate("examples/Shadow/Sim.fmu", iValue := 2, slope := 1);
+    Cont[out Double value] system = simulate("examples/Shadow/Realsys.fmu", iValue = 2, slope = 1);
+    Cont[out Double value] shadow = simulate("examples/Shadow/Sim.fmu", iValue = 2, slope = 1);
 
-    Int i := 0;
+    Int i = 0;
     while i <= 200 do
         system.tick(1.0);
         shadow.tick(1.0);
-        Double sysVal := system.value;
-        Double shaVal := shadow.value;
-        Double diff := system.value - shadow.value;
+        Double sysVal = system.value;
+        Double shaVal = shadow.value;
+        Double diff = system.value - shadow.value;
         print(diff);
-        i := i + 1;
+        i = i + 1;
     end
 end

--- a/examples/SimulationDemo/Linear.smol
+++ b/examples/SimulationDemo/Linear.smol
@@ -1,26 +1,26 @@
 main
-    Cont[out Int outPort, out Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
-    Cont[in Int inPort, out Int outPort, out Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
-    Int i := 0;
+    Cont[out Int outPort, out Int leak] de1 = simulate("examples/SimulationDemo/Linear.fmu", inPort = 2);
+    Cont[in Int inPort, out Int outPort, out Int leak] de2 = simulate("examples/SimulationDemo/Linear.fmu", inPort = 0);
+    Int i = 0;
     while(i <= 50) do
-        Int leak := de1.leak;
+        Int leak = de1.leak;
         if leak >= 10 then
-            de1.inPort := 0;
-            de2.inPort := 2;
+            de1.inPort = 0;
+            de2.inPort = 2;
         else
             if leak >= 1 then
-                de1.inPort := 1;
-                de2.inPort := 1;
+                de1.inPort = 1;
+                de2.inPort = 1;
             end
         end
 
-        Int df1 := de1.outPort;
-        Int df2 := de2.outPort;
+        Int df1 = de1.outPort;
+        Int df2 = de2.outPort;
         print("---");
         print(df1);
         print(df2);
         de1.tick(1);
         de2.tick(1);
-        i := i + 1;
+        i = i + 1;
     end
 end

--- a/examples/SimulationDemo/LinearObjects.smol
+++ b/examples/SimulationDemo/LinearObjects.smol
@@ -4,16 +4,16 @@ class WrappedSimulator(Cont[in Int inPort, out Int outPort, out Int leak] conten
 
 class Connection(WrappedSimulator from, WrappedSimulator to)
     Int propagate()
-        Int leak := this.from.content.leak;
+        Int leak = this.from.content.leak;
         if leak >= 10 then
             print("big leak");
-            this.from.content.inPort := 0;
-            this.to.content.inPort := 2;
+            this.from.content.inPort = 0;
+            this.to.content.inPort = 2;
         else
             if leak >= 1 then
                 print("small leak");
-                this.from.content.inPort := 1;
-                this.to.content.inPort := 1;
+                this.from.content.inPort = 1;
+                this.to.content.inPort = 1;
             end
         end
         return leak;
@@ -22,47 +22,47 @@ end
 
 class CoSim(List<Connection> list, List<WrappedSimulator> sims)
     Int round(Int t)
-        Int i := 0;
-        if this.list = null then return i; end
-        Int length := this.list.length();
+        Int i = 0;
+        if this.list == null then return i; end
+        Int length = this.list.length();
         while i < length do
-            Connection c := this.list.get(i);
+            Connection c = this.list.get(i);
             c.propagate();
-            i := i+1;
+            i = i+1;
         end
-        i := 0;
-        if this.sims = null then return i; end
-        length := this.sims.length();
+        i = 0;
+        if this.sims == null then return i; end
+        length = this.sims.length();
         while i < length do
-            WrappedSimulator s := this.sims.get(i);
-            Cont[] de := s.content;
+            WrappedSimulator s = this.sims.get(i);
+            Cont[] de = s.content;
             de.tick(t);
-            i := i + 1;
+            i = i + 1;
         end
         return i;
     end
 end
 
 main
-    Cont[in Int inPort, out Int outPort, out Int leak] de1 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 2);
-    Cont[in Int inPort, out Int outPort, out Int leak] de2 := simulate("examples/SimulationDemo/Linear.fmu", inPort := 0);
-    WrappedSimulator s1 := new WrappedSimulator(de1);
-    WrappedSimulator s2 := new WrappedSimulator(de2);
-    Connection c := new Connection(s1, s2);
-    List<Connection> l := new List<Connection>(c, null);
-    List<WrappedSimulator> sl := new List<WrappedSimulator>(s1, null);
-    List<WrappedSimulator> sl2 := new List<WrappedSimulator>(s2, null);
+    Cont[in Int inPort, out Int outPort, out Int leak] de1 = simulate("examples/SimulationDemo/Linear.fmu", inPort = 2);
+    Cont[in Int inPort, out Int outPort, out Int leak] de2 = simulate("examples/SimulationDemo/Linear.fmu", inPort = 0);
+    WrappedSimulator s1 = new WrappedSimulator(de1);
+    WrappedSimulator s2 = new WrappedSimulator(de2);
+    Connection c = new Connection(s1, s2);
+    List<Connection> l = new List<Connection>(c, null);
+    List<WrappedSimulator> sl = new List<WrappedSimulator>(s1, null);
+    List<WrappedSimulator> sl2 = new List<WrappedSimulator>(s2, null);
     sl.append(sl2);
-    CoSim sim := new CoSim(l, sl);
-    Int i := 0;
+    CoSim sim = new CoSim(l, sl);
+    Int i = 0;
     while(i <= 50) do
         sim.round(1);
-        Int df1 := de1.outPort;
-        Int df2 := de2.outPort;
+        Int df1 = de1.outPort;
+        Int df2 = de2.outPort;
         print("---");
         print(df1);
         print(df2);
-        i := i + 1;
+        i = i + 1;
     end
 end
 

--- a/examples/SimulationDemo/Tank.smol
+++ b/examples/SimulationDemo/Tank.smol
@@ -1,12 +1,12 @@
 main
     //beware: path is relative to interpreter instance, not this file
-    Cont[out Int filling] de := simulate("examples/SimulationDemo/Tank.fmu");
-    Int i := de.filling;
+    Cont[out Int filling] de = simulate("examples/SimulationDemo/Tank.fmu");
+    Int i = de.filling;
     print(i);
     de.tick(1);
-    i := de.filling;
+    i = de.filling;
     print(i);
     tick(de, 1);
-    i := de.filling;
+    i = de.filling;
     print(i);
 end

--- a/examples/SimulationDemo/lotka-volterra.smol
+++ b/examples/SimulationDemo/lotka-volterra.smol
@@ -5,20 +5,20 @@ class UnitObject()
 end
 class PreyObject extends UnitObject (Cont[in Double y, out Double x] prey)
     override Double get() return this.prey.x; end
-    override Double set(Double v) this.prey.y := v; return v; end
+    override Double set(Double v) this.prey.y = v; return v; end
     override Double doStep(Double step) this.prey.tick(step); return step; end
 end
 class PredatorObject extends UnitObject (Cont[in Double x, out Double y] predator)
     override Double get() return this.predator.y; end
-    override Double set(Double v) this.predator.x := v; return v; end
+    override Double set(Double v) this.predator.x = v; return v; end
     override Double doStep(Double step) this.predator.tick(step); return step; end
 end
 class CoupledPair(UnitObject a, UnitObject b, Double step)
     Int step()
         this.a.doStep(this.step);
         this.b.doStep(this.step);
-        Double fromA := this.a.get();
-        Double fromB := this.b.get();
+        Double fromA = this.a.get();
+        Double fromB = this.b.get();
         this.a.set(fromB);
         this.b.set(fromA);
         return 0;
@@ -28,15 +28,15 @@ main
 
     //beware: path is relative to interpreter instance, not this file
     //fmus are not uploaded, download them from the MasterSim examples: https://sourceforge.net/projects/mastersim/
-    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
-    PreyObject preyObj := new PreyObject(prey);
-    PredatorObject predObj := new PredatorObject(predator);
-    CoupledPair pair := new CoupledPair(preyObj, predObj, 0.1);
-    Int i := 0;
+    Cont[in Double y, out Double x] prey = simulate("examples/SimulationDemo/Prey.fmu", y = 10);
+    Cont[in Double x, out Double y] predator = simulate("examples/SimulationDemo/Predator.fmu", x = 10);
+    PreyObject preyObj = new PreyObject(prey);
+    PredatorObject predObj = new PredatorObject(predator);
+    CoupledPair pair = new CoupledPair(preyObj, predObj, 0.1);
+    Int i = 0;
     while (i <= 1000) do
         pair.step();
         print(predator.y);
-        i := i+1;
+        i = i+1;
     end
 end

--- a/examples/SimulationDemo/lv-plus.smol
+++ b/examples/SimulationDemo/lv-plus.smol
@@ -1,28 +1,28 @@
 main
     //beware: path is relative to interpreter instance, not this file
     //fmus are not uploaded, download them from the MasterSim examples: https://sourceforge.net/projects/mastersim/
-    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    prey.role := "prey";
-    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
-    Int i := 0;
+    Cont[in Double y, out Double x] prey = simulate("examples/SimulationDemo/Prey.fmu", y = 10);
+    prey.role = "prey";
+    Cont[in Double x, out Double y] predator = simulate("examples/SimulationDemo/Predator.fmu", x = 10);
+    Int i = 0;
     while (i <= 1000) do
         prey.tick(0.1);
         predator.tick(0.1);
-        prey.y := predator.y;
-        predator.x := prey.x;
-        i := i+1;
+        prey.y = predator.y;
+        predator.x = prey.x;
+        i = i+1;
     end
-    Double adv := prey.time;
-    prey := simulate("examples/SimulationDemo/Prey.fmu", y := predator.y, x := prey.x);
-    prey.role := "prey";
-    prey.pseudoOffset := adv;
-    i := 0;
+    Double adv = prey.time;
+    prey = simulate("examples/SimulationDemo/Prey.fmu", y = predator.y, x = prey.x);
+    prey.role = "prey";
+    prey.pseudoOffset = adv;
+    i = 0;
     while (i <= 1000) do
-        prey.y := predator.y;
-        predator.x := prey.x;
+        prey.y = predator.y;
+        predator.x = prey.x;
         prey.tick(0.1);
         predator.tick(0.1);
-        i := i+1;
+        i = i+1;
     end
     print("Finished");
 end

--- a/examples/SimulationDemo/lv-simple.smol
+++ b/examples/SimulationDemo/lv-simple.smol
@@ -1,15 +1,15 @@
 main
     //beware: path is relative to interpreter instance, not this file
     //fmus are not uploaded, download them from the MasterSim examples: https://sourceforge.net/projects/mastersim/
-    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
-    Int i := 0;
+    Cont[in Double y, out Double x] prey = simulate("examples/SimulationDemo/Prey.fmu", y = 10);
+    Cont[in Double x, out Double y] predator = simulate("examples/SimulationDemo/Predator.fmu", x = 10);
+    Int i = 0;
     while (i <= 2000) do
         prey.tick(0.1);
         predator.tick(0.1);
-        prey.y := predator.y;
-        predator.x := prey.x;
+        prey.y = predator.y;
+        predator.x = prey.x;
         print(predator.y);
-        i := i+1;
+        i = i+1;
     end
 end

--- a/examples/University/university.smol
+++ b/examples/University/university.smol
@@ -6,13 +6,13 @@
 // List implementation copied from another file.
 class <T> List(T content, List<T> next)
     Int length()
-        if this.next = null then return 1;
-        else Int n := this.next.length(); return n + 1;
+        if this.next == null then return 1;
+        else Int n = this.next.length(); return n + 1;
         end
     end
     Int append(List<T> last)
-        if this.next = null then
-            this.next := last;
+        if this.next == null then
+            this.next = last;
         else
             this.next.append(last);
         end
@@ -20,21 +20,21 @@ class <T> List(T content, List<T> next)
     end
 
     T get(Int i)
-        T res := this.content;
+        T res = this.content;
         if i >= 1 then
-            res := this.next.get(i-1);
+            res = this.next.get(i-1);
         end
         return res;
     end
 
     Boolean contains(T element)
-        if this.content = element then
+        if this.content == element then
             return True;
         else
-            if this.next = null then
+            if this.next == null then
                 return False;
             else
-                Boolean res := this.next.contains(element);
+                Boolean res = this.next.contains(element);
                 return res;
             end
         end
@@ -68,7 +68,7 @@ class Person (private Int personId, private String name, private Int birthYear, 
 
     // Testing rule and domain keywords
     rule Int ruleAge()
-        Int res := 2021-this.birthYear;
+        Int res = 2021-this.birthYear;
         return res;
     end
     rule String ruleLastName()
@@ -85,7 +85,7 @@ class Person (private Int personId, private String name, private Int birthYear, 
         return this.height-1.0;
     end
     domain Int domainAge()
-        Int res := 2021-this.birthYear;
+        Int res = 2021-this.birthYear;
         return res;
     end
     domain Double domainHeightMinusOne()
@@ -136,18 +136,18 @@ end
 
 main
     // Short example using while loop
-    Int counter := 2;
+    Int counter = 2;
     while (counter <= 4) do
-        Person a := new Person(13025213498, "Irina", 1952, 1.78);
-        counter := counter + 1;
+        Person a = new Person(13025213498, "Irina", 1952, 1.78);
+        counter = counter + 1;
     end
 
     // The first Person
-    Person alice := new Person(13025213498, "Alice", 1952, 1.78);
-    Int aliceId := alice.getPersonId();
-    Int aliceName := alice.getName();
-    Int aliceBirthYear := alice.getBirthYear();
-    Double aliceHeight := alice.getHeight();
+    Person alice = new Person(13025213498, "Alice", 1952, 1.78);
+    Int aliceId = alice.getPersonId();
+    Int aliceName = alice.getName();
+    Int aliceBirthYear = alice.getBirthYear();
+    Double aliceHeight = alice.getHeight();
     // print("Name, id and birthyear of Alice:");
     // print(aliceName);
     // print(aliceId);
@@ -155,66 +155,66 @@ main
     // print(aliceHeight);
 
     // Departments
-    Department mathDep := new Department(1, "Department of Mathematics");
-    Department csDep := new Department(2, "Department of Computer Science");
+    Department mathDep = new Department(1, "Department of Mathematics");
+    Department csDep = new Department(2, "Department of Computer Science");
 
     // Employees
-    Employee charlie := new Employee(29017413549, "Charlie", 1974, 1.91, 1, mathDep);
-    Employee dave := new Employee(2110195093381, "Dave", 1950, 1.76, 2, csDep);
-    AssociateProfessor ella := new AssociateProfessor(04036204431, "Ella", 1962, 1.86, 3, mathDep);
-    Professor greg := new Professor(05075043523, "Dave", 1950, 1.84, 2, csDep);
+    Employee charlie = new Employee(29017413549, "Charlie", 1974, 1.91, 1, mathDep);
+    Employee dave = new Employee(2110195093381, "Dave", 1950, 1.76, 2, csDep);
+    AssociateProfessor ella = new AssociateProfessor(04036204431, "Ella", 1962, 1.86, 3, mathDep);
+    Professor greg = new Professor(05075043523, "Dave", 1950, 1.84, 2, csDep);
 
     // Courses
-    Course calculus1 := new Course("M1001", "Calculus 1", mathDep, greg);
-    Course calculus2 := new Course("M2001", "Calculus 2", mathDep, charlie);
-    Course linearAlgebra := new Course("M2002", "Linear Algebra", mathDep, charlie);
-    Course discreteMathematics := new Course("M1002", "Discrete Mathematics", mathDep, charlie);
-    Course logic := new Course("M2020", "Logic", mathDep, charlie);
-    Course introToProgramming := new Course("C1001", "Introduction to Programming", csDep, dave);
+    Course calculus1 = new Course("M1001", "Calculus 1", mathDep, greg);
+    Course calculus2 = new Course("M2001", "Calculus 2", mathDep, charlie);
+    Course linearAlgebra = new Course("M2002", "Linear Algebra", mathDep, charlie);
+    Course discreteMathematics = new Course("M1002", "Discrete Mathematics", mathDep, charlie);
+    Course logic = new Course("M2020", "Logic", mathDep, charlie);
+    Course introToProgramming = new Course("C1001", "Introduction to Programming", csDep, dave);
 
     // Students
-    Student bob := new Student(24098845521, "Bob", 1988, 1.77, 1001, True) models "rdf:type smol:StudentInstance; smol:bio 'I am a 33 year old student who likes to solve math problems'; smol:age 33; smol:isEnrolled true; smol:friend run:obj15.";
-    Student eve := new Student(11118694402, "Eve", 1986, 1.66, 1002, False);
-    Student fred := new Student(09058894388, "Fred", 1988, 1.75, 1003, True);
+    Student bob = new Student(24098845521, "Bob", 1988, 1.77, 1001, True) models "rdf:type smol:StudentInstance; smol:bio 'I am a 33 year old student who likes to solve math problems'; smol:age 33; smol:isEnrolled true; smol:friend run:obj15.";
+    Student eve = new Student(11118694402, "Eve", 1986, 1.66, 1002, False);
+    Student fred = new Student(09058894388, "Fred", 1988, 1.75, 1003, True);
 
     // Get and print all Persons (no reasoning)
-    // List<Person> allPersons := access("SELECT ?obj WHERE{ ?obj a prog:Person. }");
-    // Int personLen := allPersons.length();
+    // List<Person> allPersons = access("SELECT ?obj WHERE{ ?obj a prog:Person. }");
+    // Int personLen = allPersons.length();
     // print(personLen);
-    // Int i := 0;
+    // Int i = 0;
     // print("Persons:");
     // while (i < personLen) do
-    //     Person person := allPersons.get(i);
-    //     String personName := person.toString();
+    //     Person person = allPersons.get(i);
+    //     String personName = person.toString();
     //     print(personName);
-    //     i := i+1;
+    //     i = i+1;
     // end
 
     // Get and print all Students (no reasoning)
-    // List<Student> allStudents := access("SELECT ?obj WHERE{ ?obj a prog:Student. }");
-    // Int studentLen := allStudents.length();
+    // List<Student> allStudents = access("SELECT ?obj WHERE{ ?obj a prog:Student. }");
+    // Int studentLen = allStudents.length();
     // print(studentLen);
-    // i := 0;
+    // i = 0;
     // print("Students:");
     // while (i < studentLen) do
-    //     Student student := allStudents.get(i);
-    //     String studentName := student.toString();
+    //     Student student = allStudents.get(i);
+    //     String studentName = student.toString();
     //     print(studentName);
-    //     i := i+1;
+    //     i = i+1;
     // end
 
     // Testing SHACL shapes (with reasoning)
-    // Boolean b := validate("examples/University/university.ttl");
+    // Boolean b = validate("examples/University/university.ttl");
     // print("Check if all lecturers are actually employees:");
     // print(b);
 
 
     // TODO: Get and print (with Hermit reasoning) It complains about my list implementation.
-    // List<Person> m := derive("prog:Banana");
+    // List<Person> m = derive("prog:Banana");
 
 
     // Testing that type checking works by assigning an int to a string variable.
-    String str := 5;
+    String str = 5;
 
 
 end

--- a/examples/construct.smol
+++ b/examples/construct.smol
@@ -9,25 +9,25 @@ class B(A a, Int i2) end
 class C(Int j1, Int j2) end
 
 main
-    A a1 := new A(1);
-    A a2 := new A(2);
-    A a3 := new A(1);
-    A a4 := new A(2);
-    B b0 := new B(null, 3);
-    B b1 := new B(a1, 4);
-    B b2 := new B(a2, 5);
-    B b3 := new B(a3, 6);
-    B b4 := new B(a4, 7);
+    A a1 = new A(1);
+    A a2 = new A(2);
+    A a3 = new A(1);
+    A a4 = new A(2);
+    B b0 = new B(null, 3);
+    B b1 = new B(a1, 4);
+    B b2 = new B(a2, 5);
+    B b3 = new B(a3, 6);
+    B b4 = new B(a4, 7);
 
-    List<C> v := construct("SELECT ?j1 ?j2 WHERE { ?y a prog:B. ?y prog:B_i2 ?j2.?y prog:B_a ?x.?x a prog:A. ?x prog:A_i1 ?j1 }");
-    Int i := 0;
-    Int size := v.length();
+    List<C> v = construct("SELECT ?j1 ?j2 WHERE { ?y a prog:B. ?y prog:B_i2 ?j2.?y prog:B_a ?x.?x a prog:A. ?x prog:A_i1 ?j1 }");
+    Int i = 0;
+    Int size = v.length();
     while( i < size) do
-        C next := v.get(i);
+        C next = v.get(i);
         print(next.j1);
         print(next.j2);
         print("___");
-        i := i + 1;
+        i = i + 1;
     end
     print(size);
 end

--- a/examples/destroy.smol
+++ b/examples/destroy.smol
@@ -3,12 +3,12 @@ class A(Int i1) end
 
 main
 
-    A a := new A(1);
-    List<A> list := access("SELECT ?obj WHERE {?obj a prog:A}");
+    A a = new A(1);
+    List<A> list = access("SELECT ?obj WHERE {?obj a prog:A}");
     print(list);
     print(list.content);
     destroy(a);
     print(list.content);
-    list := access("SELECT ?obj WHERE {?obj a prog:A}");
+    list = access("SELECT ?obj WHERE {?obj a prog:A}");
     print(list);
 end

--- a/examples/influx.smol
+++ b/examples/influx.smol
@@ -1,6 +1,6 @@
 
 main
-    List<Double> list := access(
+    List<Double> list = access(
       "from(bucket: \"petwin\")
       |>  range(start: -1h, stop: -1m)
       |> filter(fn: (r) => r[\"_measurement\"] == \"chili\")

--- a/examples/models.smol
+++ b/examples/models.smol
@@ -1,13 +1,13 @@
 
 class M(Int i)
-   models( this.i = 0 ) "rdf:type domain:zero.";
-   models( this.i = 1 ) "rdf:type domain:single.";
+   models( this.i == 0 ) "rdf:type domain:zero.";
+   models( this.i == 1 ) "rdf:type domain:single.";
    models "rdf:type domain:any.";
 end
 
 main
-   M v0 := new M(0);
-   M v1 := new M(1);
-   M v2 := new M(2);
-   List<M> acc := access("SELECT ?obj WHERE {?obj rdf:type prog:M}");
+   M v0 = new M(0);
+   M v1 = new M(1);
+   M v2 = new M(2);
+   List<M> acc = access("SELECT ?obj WHERE {?obj rdf:type prog:M}");
 end

--- a/examples/newgeo.smol
+++ b/examples/newgeo.smol
@@ -5,7 +5,7 @@ end
 class DepositAction extends Action (nonsemantic GeoLayer deposit)
     override Unit execute(Scenario scen)
         //print("deposit");
-        this.deposit.scenId := scen.scenId;
+        this.deposit.scenId = scen.scenId;
         scen.deposit(this.deposit);
         if(this.advance) then
             scen.processes();
@@ -34,10 +34,10 @@ end
 
 abstract class GeoLayer(Int scenId, domain Int thickness, nonsemantic GeoLayer above, nonsemantic GeoLayer below) //in m
     domain Int depth()
-        Int res := 0;
-        if(this.above <> null) then
-            res := this.above.depth();
-            res := res + this.above.thickness;
+        Int res = 0;
+        if(this.above != null) then
+            res = this.above.depth();
+            res = res + this.above.thickness;
         end
         return res;
     end
@@ -59,38 +59,38 @@ class UnknownLayer extends GeoLayer()
 end
 
 class Shale extends GeoLayer(Int dinoStatus) //0 = none, 1 = deposit, 2 = kerogen, 3 = volatile
-            models(this.dinoStatus = 1) "rdf:type owl:NamedIndividual; rdf:type domain:Stratigraphic_Layer; domain:constitutedBy [rdf:type domain:Shale]; domain:constitutedBy [domain:contains [rdf:type domain:Kerogen]].";
-            models(this.dinoStatus = 2) "rdf:type owl:NamedIndividual; rdf:type domain:Stratigraphic_Layer; domain:constitutedBy [rdf:type domain:Shale]; domain:constitutedBy [domain:contains [rdf:type domain:Kerogen]].";
+            models(this.dinoStatus == 1) "rdf:type owl:NamedIndividual; rdf:type domain:Stratigraphic_Layer; domain:constitutedBy [rdf:type domain:Shale]; domain:constitutedBy [domain:contains [rdf:type domain:Kerogen]].";
+            models(this.dinoStatus == 2) "rdf:type owl:NamedIndividual; rdf:type domain:Stratigraphic_Layer; domain:constitutedBy [rdf:type domain:Shale]; domain:constitutedBy [domain:contains [rdf:type domain:Kerogen]].";
             models "rdf:type owl:NamedIndividual; rdf:type domain:Stratigraphic_Layer; domain:constitutedBy [rdf:type domain:Shale].";
     Unit cook()
         //if(this.dinoStatus < 3 & this.dinoStatus > 0) then
         print("cooking");
         //print(this);
-        this.dinoStatus := this.dinoStatus +1;
+        this.dinoStatus = this.dinoStatus +1;
     end
     Unit burn()
-        this.dinoStatus := 0;
+        this.dinoStatus = 0;
         print("burning");
     end
     override Boolean canPropagate()
         return False;
     end
     override Boolean migrate()
-        if(this.above <> null) then
-            Boolean unsealed := this.above.canPropagate();
+        if(this.above != null) then
+            Boolean unsealed = this.above.canPropagate();
             if(unsealed) then
                 this.above.migrate();
-                this.dinoStatus := 0;
+                this.dinoStatus = 0;
                 return False;
             end
         else
-            this.dinoStatus := 0;
+            this.dinoStatus = 0;
             return False;
         end
         return True;
     end
     override GeoLayer clone(Int id)
-        GeoLayer newLayer := new Shale(id, this.thickness ,this.above ,this.below, this.dinoStatus);
+        GeoLayer newLayer = new Shale(id, this.thickness ,this.above ,this.below, this.dinoStatus);
         return newLayer;
     end
 end
@@ -99,31 +99,31 @@ class Sand extends GeoLayer(Int porosity, Boolean hasHC) //1 = high, 2 = medium,
            models(this.hasHC) "rdf:type owl:NamedIndividual; rdf:type domain:Stratigraphic_Layer; domain:constitutedBy [rdf:type domain:Sandstone];  domain:constitutedBy [domain:contains [rdf:type domain:Kerogen]].";
            models "rdf:type owl:NamedIndividual; rdf:type domain:Stratigraphic_Layer; domain:constitutedBy [rdf:type domain:Sandstone].";
     Unit compact()
-        if(this.porosity < 3) then this.porosity := this.porosity +1; end
+        if(this.porosity < 3) then this.porosity = this.porosity +1; end
         print("compacting");
     end
     override Boolean canPropagate()
         return this.porosity < 3;
     end
     override Boolean migrate()
-        this.hasHC := True;
-        if(this.above <> null) then
-            Boolean unsealed := this.above.canPropagate();
+        this.hasHC = True;
+        if(this.above != null) then
+            Boolean unsealed = this.above.canPropagate();
             if(unsealed) then
                 this.above.migrate();
-                this.hasHC := False;
+                this.hasHC = False;
                 return False;
             end
         else
             print("escape");
-            this.hasHC := False;
+            this.hasHC = False;
             return False;
         end
         if(this.hasHC) then print("deposit"); end
         return True;
     end
     override GeoLayer clone(Int id)
-        GeoLayer newLayer := new Sand(id, this.thickness ,this.above ,this.below, this.porosity, this.hasHC);
+        GeoLayer newLayer = new Sand(id, this.thickness ,this.above ,this.below, this.porosity, this.hasHC);
         return newLayer;
     end
 end
@@ -142,31 +142,31 @@ end
 
 class Scenario(Int scenId, Bedrock basis, GeoLayer top)
     Scenario clone(Int id)
-        Bedrock newBasis := new Bedrock(id, this.basis.thickness, null, null);
-        Scenario newScen := new Scenario(id, newBasis, newBasis);
-        GeoLayer next := this.basis;
-        while(next.above <> null) do
-            next := next.above;
-            GeoLayer newNext := next.clone(id);
+        Bedrock newBasis = new Bedrock(id, this.basis.thickness, null, null);
+        Scenario newScen = new Scenario(id, newBasis, newBasis);
+        GeoLayer next = this.basis;
+        while(next.above != null) do
+            next = next.above;
+            GeoLayer newNext = next.clone(id);
             newScen.deposit(newNext);
         end
         return newScen;
     end
     Unit deposit(GeoLayer newLayer)
-        newLayer.below := this.top;
-        this.top.above := newLayer;
-        this.top := newLayer;
+        newLayer.below = this.top;
+        this.top.above = newLayer;
+        this.top = newLayer;
     end
     Unit erode(Int meters) //beware, no null check this.top.below
         if(this.top.thickness <= meters) then
-            GeoLayer old := this.top;
-            Int up := meters - old.thickness;
-            this.top := this.top.below;
-            this.top.above := null;
+            GeoLayer old = this.top;
+            Int up = meters - old.thickness;
+            this.top = this.top.below;
+            this.top.above = null;
             destroy(old);
             this.erode(up);
         else
-            this.top.thickness := this.top.thickness - meters;
+            this.top.thickness = this.top.thickness - meters;
         end
     end
 
@@ -176,87 +176,87 @@ class Scenario(Int scenId, Bedrock basis, GeoLayer top)
 
     Unit processes()
        print("pr");
-       List<Sand> geos := access("SELECT DISTINCT ?obj WHERE { ?obj prog:GeoLayer_depth_builtin_res ?depth. ?obj a prog:Sand. ?obj prog:Sand_scenId %1. FILTER(?depth >= 3000) }", this.scenId);
-       while(geos <> null) do
-            Sand next := geos.content;
+       List<Sand> geos = access("SELECT DISTINCT ?obj WHERE { ?obj prog:GeoLayer_depth_builtin_res ?depth. ?obj a prog:Sand. ?obj prog:Sand_scenId %1. FILTER(?depth >= 3000) }", this.scenId);
+       while(geos != null) do
+            Sand next = geos.content;
             next.compact();
-            geos := geos.next;
+            geos = geos.next;
        end
 //       breakpoint;
-       List<Shale> geos2 :=
+       List<Shale> geos2 =
 //       access("SELECT DISTINCT ?obj WHERE{ ?obj prog:Shale_scenId %1. ?obj domain:models ?y. ?y rdf:type domain:CookingTriggerSmall; domain:GeoLayer_depth_builtin_res ?depth. FILTER(?depth >= 2000)  }", this.scenId);
 //        access("SELECT DISTINCT ?obj WHERE{ ?obj domain:models ?y. ?y rdf:type domain:CookingTriggerSmall; domain:GeoLayer_depth_builtin_res ?depth. FILTER(?depth >= 2000) }");
         member("<domain:models> some <domain:CookingTrigger>");
-       while(geos2 <> null) do
-            Shale next2 := geos2.content;
+       while(geos2 != null) do
+            Shale next2 = geos2.content;
             next2.cook();
-            geos2 := geos2.next;
+            geos2 = geos2.next;
        end
-       geos2 := access("SELECT DISTINCT ?obj WHERE { ?obj prog:GeoLayer_depth_builtin_res ?depth. ?obj a prog:Shale. ?obj prog:Shale_scenId %1. FILTER(?depth > 4000) }", this.scenId);
-       while(geos2 <> null) do
-           next2 := geos2.content;
+       geos2 = access("SELECT DISTINCT ?obj WHERE { ?obj prog:GeoLayer_depth_builtin_res ?depth. ?obj a prog:Shale. ?obj prog:Shale_scenId %1. FILTER(?depth > 4000) }", this.scenId);
+       while(geos2 != null) do
+           next2 = geos2.content;
            next2.burn();
-           geos2 := geos2.next;
+           geos2 = geos2.next;
        end
-       geos := access("SELECT DISTINCT ?obj WHERE { ?obj prog:GeoLayer_depth_builtin_res ?depth. ?obj a prog:Sand. ?obj prog:Sand_scenId %1. FILTER(?depth >= 4000) }", this.scenId);
-       while(geos <> null) do
-           next := geos.content;
-           next.hasHC := False; //burning in sand
-           geos := geos.next;
+       geos = access("SELECT DISTINCT ?obj WHERE { ?obj prog:GeoLayer_depth_builtin_res ?depth. ?obj a prog:Sand. ?obj prog:Sand_scenId %1. FILTER(?depth >= 4000) }", this.scenId);
+       while(geos != null) do
+           next = geos.content;
+           next.hasHC = False; //burning in sand
+           geos = geos.next;
        end
-      // geos2 := access("SELECT DISTINCT ?obj WHERE { ?obj prog:Shale_dinoStatus 3. ?obj prog:Shale_scenId %1 }", this.scenId);
-       geos2 := access("SELECT DISTINCT ?obj WHERE { ?obj prog:Shale_dinoStatus 3 }");
-       while(geos2 <> null) do
-           next2 := geos2.content;
+      // geos2 = access("SELECT DISTINCT ?obj WHERE { ?obj prog:Shale_dinoStatus 3. ?obj prog:Shale_scenId %1 }", this.scenId);
+       geos2 = access("SELECT DISTINCT ?obj WHERE { ?obj prog:Shale_dinoStatus 3 }");
+       while(geos2 != null) do
+           next2 = geos2.content;
            next2.migrate();
-           geos2 := geos2.next;
+           geos2 = geos2.next;
        end
     end
 
     Unit run(List<Action> actions)
-        List<Action> current := actions;
-        while(current <> null) do
-            Action next := current.content;
+        List<Action> current = actions;
+        while(current != null) do
+            Action next = current.content;
             next.execute(this);
-            current := current.next;
+            current = current.next;
         end
     end
 end
 
 main
-    GeoLayer layer := new Shale(0, 1000, null, null, 1);
-    Action action := new DepositAction(True, layer);
-    List<Action> actions := new List<Action>(action, null);
+    GeoLayer layer = new Shale(0, 1000, null, null, 1);
+    Action action = new DepositAction(True, layer);
+    List<Action> actions = new List<Action>(action, null);
 
-    layer := new Sand(0, 1000, null, null, 1, False);
-    action := new DepositAction(True, layer);
-    actions := new List<Action>(action, actions);
+    layer = new Sand(0, 1000, null, null, 1, False);
+    action = new DepositAction(True, layer);
+    actions = new List<Action>(action, actions);
 
-    layer := new Sand(0, 1000, null, null, 1, False);
-    //layer := new Shale(0, 1000, null, null, 0);
-    action := new DepositAction(True, layer);
-    actions := new List<Action>(action, actions);
+    layer = new Sand(0, 1000, null, null, 1, False);
+    //layer = new Shale(0, 1000, null, null, 0);
+    action = new DepositAction(True, layer);
+    actions = new List<Action>(action, actions);
 
-    action := new EmptyAction(True);
-    actions := new List<Action>(action, actions);
+    action = new EmptyAction(True);
+    actions = new List<Action>(action, actions);
 
-    action := new ErodeAction(True, 1500);
-    actions := new List<Action>(action, actions);
+    action = new ErodeAction(True, 1500);
+    actions = new List<Action>(action, actions);
 
-    layer := new Sand(0, 1000, null, null, 1, False);
-    action := new DepositAction(True, layer);
-    actions := new List<Action>(action, actions);
+    layer = new Sand(0, 1000, null, null, 1, False);
+    action = new DepositAction(True, layer);
+    actions = new List<Action>(action, actions);
 
-    layer := new Sand(0, 1000, null, null, 1, False);
-    action := new DepositAction(True, layer);
-    actions := new List<Action>(action, actions);
+    layer = new Sand(0, 1000, null, null, 1, False);
+    action = new DepositAction(True, layer);
+    actions = new List<Action>(action, actions);
 
-    action := new EmptyAction(True);
-    actions := new List<Action>(action, actions);
+    action = new EmptyAction(True);
+    actions = new List<Action>(action, actions);
 
-    Bedrock bed := new Bedrock(1, 1000, null, null);
-    Scenario scen := new Scenario(1, bed, bed);
+    Bedrock bed = new Bedrock(1, 1000, null, null);
+    Scenario scen = new Scenario(1, bed, bed);
 
-    actions := actions.reverse();
+    actions = actions.reverse();
     scen.run(actions);
 end

--- a/examples/translatescene.smol
+++ b/examples/translatescene.smol
@@ -6,14 +6,14 @@ end
 
 class Rectangle(Scene scene, Int w, Int h, String name)
     Int area()
-        Int s := this.scene.getScale();
+        Int s = this.scene.getScale();
         return s*this.w*this.h;
     end
 end
 
 main
-    Scene sc := new Scene(2);
-    Rectangle r := new Rectangle(sc, 5, 1, "rect1");
-    Int res := r.area();
+    Scene sc = new Scene(2);
+    Rectangle r = new Rectangle(sc, 5, 1, "rect1");
+    Int res = r.area();
     print(res);
 end

--- a/examples/type_query.smol
+++ b/examples/type_query.smol
@@ -1,72 +1,72 @@
 
 class A (protected Int f1, private Int f2, Int f3)
     Int m1(A a, B b, C c)
-        Int v1 := this.f1 + this.f2 + this.f3;
-        Int v2 := b.f4; //fail
-        Int v3 := b.f5; //fail
-        Int v4 := b.f6;
-        Int v5 := b.f1;
-        Int v6 := b.f2;
-        Int v7 := b.f3;
-        Int w5 := a.f1;
-        Int w6 := a.f2;
-        Int w7 := a.f3;
-        Int v8 := c.f7; //fail
-        Int v9 := c.f8; //fail
-        Int v0 := c.f9;
+        Int v1 = this.f1 + this.f2 + this.f3;
+        Int v2 = b.f4; //fail
+        Int v3 = b.f5; //fail
+        Int v4 = b.f6;
+        Int v5 = b.f1;
+        Int v6 = b.f2;
+        Int v7 = b.f3;
+        Int w5 = a.f1;
+        Int w6 = a.f2;
+        Int w7 = a.f3;
+        Int v8 = c.f7; //fail
+        Int v9 = c.f8; //fail
+        Int v0 = c.f9;
         return 0;
     end
 end
 
 class B extends A (protected Int f4, private Int f5, Int f6)
     Int m2(A a, B b, C c)
-        Int v1 := this.f4 + this.f5 + this.f6;
-        Int v2 := b.f4;
-        Int v3 := b.f5;
-        Int v4 := b.f6;
-        Int v5 := b.f1;
-        Int v6 := b.f2; //fail
-        Int v7 := b.f3;
-        Int w5 := a.f1;
-        Int w6 := a.f2; //fail
-        Int w7 := a.f3;
-        Int v8 := c.f7; //fail
-        Int v9 := c.f8; //fail
-        Int v0 := c.f9;
+        Int v1 = this.f4 + this.f5 + this.f6;
+        Int v2 = b.f4;
+        Int v3 = b.f5;
+        Int v4 = b.f6;
+        Int v5 = b.f1;
+        Int v6 = b.f2; //fail
+        Int v7 = b.f3;
+        Int w5 = a.f1;
+        Int w6 = a.f2; //fail
+        Int w7 = a.f3;
+        Int v8 = c.f7; //fail
+        Int v9 = c.f8; //fail
+        Int v0 = c.f9;
         return 0;
     end
 end
 
 class C extends A(protected Int f7, private Int f8, Int f9)
     Int m3(A a, B b, C c)
-        Int v1 := this.f7 + this.f8 + this.f9;
-        Int v2 := b.f4; //fail
-        Int v3 := b.f5; //fail
-        Int v4 := b.f6;
-        Int v5 := b.f1;
-        Int v6 := b.f2; //fail
-        Int v7 := b.f3;
-        Int w5 := a.f1;
-        Int w6 := a.f2; //fail
-        Int w7 := a.f3;
-        Int v8 := c.f7;
-        Int v9 := c.f8;
-        Int v0 := c.f9;
+        Int v1 = this.f7 + this.f8 + this.f9;
+        Int v2 = b.f4; //fail
+        Int v3 = b.f5; //fail
+        Int v4 = b.f6;
+        Int v5 = b.f1;
+        Int v6 = b.f2; //fail
+        Int v7 = b.f3;
+        Int w5 = a.f1;
+        Int w6 = a.f2; //fail
+        Int w7 = a.f3;
+        Int v8 = c.f7;
+        Int v9 = c.f8;
+        Int v0 = c.f9;
         return 0;
     end
 end
 
 class D extends A()
     Int m4(A a, B b, C c)
-        a.f1 := 1;
-        a.f2 := 1; //fail
-        a.f3 := 1;
-        b.f4 := 1; //fail
-        b.f5 := 1; //fail
-        b.f6 := 1;
-        c.f7 := 1; //fail
-        c.f8 := 1; //fail
-        c.f9 := 1;
+        a.f1 = 1;
+        a.f2 = 1; //fail
+        a.f3 = 1;
+        b.f4 = 1; //fail
+        b.f5 = 1; //fail
+        b.f6 = 1;
+        c.f7 = 1; //fail
+        c.f8 = 1; //fail
+        c.f9 = 1;
         return 0;
     end
 end

--- a/src/main/antlr/While.g4
+++ b/src/main/antlr/While.g4
@@ -55,13 +55,13 @@ THIS: 'this';
 UNIT: 'unit';
 
 //Keywords: operators
-EQ : '=';
-NEQ : '<>';
+EQ : '==';
+NEQ : '!=';
 LT : '<';
 GT : '>';
 LEQ : '<=';
 GEQ : '>=';
-ASS : ':=';
+ASS : '=';
 PLUS : '+';
 MULT : '*';
 MINUS : '-';

--- a/src/main/resources/StdLib.smol
+++ b/src/main/resources/StdLib.smol
@@ -1,14 +1,14 @@
 class List<LISTT>(LISTT content, List<LISTT> next)
 
     Int length()
-        if this.next = null then return 1;
-        else Int n := this.next.length(); return n + 1;
+        if this.next == null then return 1;
+        else Int n = this.next.length(); return n + 1;
         end
     end
 
     Int append(List<LISTT> last)
-        if this.next = null then
-            this.next := last;
+        if this.next == null then
+            this.next = last;
         else
             this.next.append(last);
         end
@@ -16,42 +16,42 @@ class List<LISTT>(LISTT content, List<LISTT> next)
     end
 
     LISTT get(Int i)
-        LISTT res := this.content;
+        LISTT res = this.content;
         if i >= 1 then
-            res := this.next.get(i - 1);
+            res = this.next.get(i - 1);
         end
         return res;
     end
 
     Boolean contains(LISTT element)
-        if this.content = element then
+        if this.content == element then
             return True;
         else
-            if this.next = null then
+            if this.next == null then
                 return False;
             else
-                Boolean res := this.next.contains(element);
+                Boolean res = this.next.contains(element);
                 return res;
             end
         end
     end
 
     List<LISTT> reverse()
-        if(this.next = null) then
+        if(this.next == null) then
             return this;
         else
-            List<LISTT> ret := this.next.reverse();
-            this.next.next := this;
-            this.next := null;
+            List<LISTT> ret = this.next.reverse();
+            this.next.next = this;
+            this.next = null;
             return ret;
         end
     end
 
     LISTT last()
-        if(this.next = null) then
+        if(this.next == null) then
             return this.content;
         else
-            LISTT last := this.next.last();
+            LISTT last = this.next.last();
             return last;
         end
     end

--- a/src/test/kotlin/no/uio/microobject/test/execution/FMOLExecutionTest.kt
+++ b/src/test/kotlin/no/uio/microobject/test/execution/FMOLExecutionTest.kt
@@ -11,8 +11,8 @@ class FMOLExecutionTest: MicroObjectTest() {
     init {
         "adder 1" {
             val stmt = """
-                Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu", ra := 1.0, rb := 1.0);
-                Double res := fmu1.rc;
+                Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu", ra = 1.0, rb = 1.0);
+                Double res = fmu1.rc;
                 breakpoint;
                 print(res);
             """.trimIndent()
@@ -23,9 +23,9 @@ class FMOLExecutionTest: MicroObjectTest() {
         }
         "linear 1" {
             val stmt = """
-                Cont[out Int outPort] fmu1 := simulate("src/test/resources/linear.fmu", inPort := 1);
+                Cont[out Int outPort] fmu1 = simulate("src/test/resources/linear.fmu", inPort = 1);
                 fmu1.tick(1.0);
-                Int res := fmu1.outPort;
+                Int res = fmu1.outPort;
                 breakpoint;
                 print(outPort);
             """.trimIndent()

--- a/src/test/kotlin/no/uio/microobject/test/execution/MOLExecutionTest.kt
+++ b/src/test/kotlin/no/uio/microobject/test/execution/MOLExecutionTest.kt
@@ -17,7 +17,7 @@ class MOLExecutionTest : MicroObjectTest() {
     init {
         "Add"{
             val v = LocalVar("v", INTTYPE)
-            val (a,_) = initInterpreter(" Int v := 1 + 2; v := v + 2; v := v + -1; breakpoint;",StringLoad.STMT)
+            val (a,_) = initInterpreter(" Int v = 1 + 2; v = v + 2; v = v + -1; breakpoint;",StringLoad.STMT)
             a.makeStep();
             assertEquals(1, a.stack.size)
             assert(a.stack.peek().store.containsKey("v"))
@@ -35,7 +35,7 @@ class MOLExecutionTest : MicroObjectTest() {
             assertEquals(LiteralExpr("4", INTTYPE), a.evalTopMost(v))
         }
         "Minus"{
-            val (a,_) = initInterpreter(" Int v := 2 - 1; v := v - -1; breakpoint;",StringLoad.STMT)
+            val (a,_) = initInterpreter(" Int v = 2 - 1; v = v - -1; breakpoint;",StringLoad.STMT)
             a.makeStep();
             assertEquals(1, a.stack.size)
             assert(a.stack.peek().store.containsKey("v"))
@@ -46,7 +46,7 @@ class MOLExecutionTest : MicroObjectTest() {
             assertEquals(LiteralExpr("2", INTTYPE), a.stack.peek().store["v"])
         }
         "Mult"{
-            val (a,_) = initInterpreter(" Double v := 1.0 * 2.0; v := v * -1.0e0; breakpoint;",StringLoad.STMT)
+            val (a,_) = initInterpreter(" Double v = 1.0 * 2.0; v = v * -1.0e0; breakpoint;",StringLoad.STMT)
             a.makeStep();
             assertEquals(1, a.stack.size)
             assert(a.stack.peek().store.containsKey("v"))
@@ -57,7 +57,7 @@ class MOLExecutionTest : MicroObjectTest() {
             assertEquals(LiteralExpr("-2.0", DOUBLETYPE), a.stack.peek().store["v"])
         }
         "Div"{
-            val (a,_) = initInterpreter(" Double v := 2.0 / 1.0; v := v / -1.0e0; breakpoint;",StringLoad.STMT)
+            val (a,_) = initInterpreter(" Double v = 2.0 / 1.0; v = v / -1.0e0; breakpoint;",StringLoad.STMT)
             a.makeStep();
             assertEquals(1, a.stack.size)
             assert(a.stack.peek().store.containsKey("v"))
@@ -68,21 +68,21 @@ class MOLExecutionTest : MicroObjectTest() {
             assertEquals(LiteralExpr("-2.0", DOUBLETYPE), a.stack.peek().store["v"])
         }
         "Bool"{
-            val (a,_) = initInterpreter(" Boolean v := (2 > 0 & 2 >= 0) | ( 2 < 0 & !(2 <= 0)); breakpoint;",StringLoad.STMT)
+            val (a,_) = initInterpreter(" Boolean v = (2 > 0 & 2 >= 0) | ( 2 < 0 & !(2 <= 0)); breakpoint;",StringLoad.STMT)
             a.makeStep();
             assertEquals(1, a.stack.size)
             assert(a.stack.peek().store.containsKey("v"))
             assertEquals(TRUEEXPR, a.stack.peek().store["v"])
         }
         "Neq"{
-            val (a,_) = initInterpreter(" Boolean v := 2 <> 1; breakpoint;",StringLoad.STMT)
+            val (a,_) = initInterpreter(" Boolean v = 2 != 1; breakpoint;",StringLoad.STMT)
             a.makeStep();
             assertEquals(1, a.stack.size)
             assert(a.stack.peek().store.containsKey("v"))
             assertEquals(TRUEEXPR, a.stack.peek().store["v"])
         }
         "Eq"{
-            val (a,_) = initInterpreter(" Boolean v := 2 = 1; breakpoint;",StringLoad.STMT)
+            val (a,_) = initInterpreter(" Boolean v = 2 == 1; breakpoint;",StringLoad.STMT)
             a.makeStep();
             assertEquals(1, a.stack.size)
             assert(a.stack.peek().store.containsKey("v"))

--- a/src/test/resources/Jacobi.smol
+++ b/src/test/resources/Jacobi.smol
@@ -15,7 +15,7 @@ end
 
 class ImplConnection extends Connection (OutPort<Double> from, InPort<Double> to)
     override Int propagate()
-        Double val := this.from.get();
+        Double val = this.from.get();
         this.to.write(val);
         return 0;
     end
@@ -24,30 +24,30 @@ end
 //Jacobi master algorithm: propagate through all connections, advance time for all FMUs at once
 class CoSim(List<Connection> list, List<Cont[]> sims, Double stepSize)
     Int round()
-        Int i := 0;
-        if this.list = null then return i; end
-        Int length := this.list.length();
+        Int i = 0;
+        if this.list == null then return i; end
+        Int length = this.list.length();
         while i < length do
-            Connection c := this.list.get(i);
+            Connection c = this.list.get(i);
             c.propagate();
-            i := i+1;
+            i = i+1;
         end
-        i := 0;
-        if this.sims = null then return i; end
-        length := this.sims.length();
+        i = 0;
+        if this.sims == null then return i; end
+        length = this.sims.length();
         while i < length do
-            Cont[] de := this.sims.get(i);
+            Cont[] de = this.sims.get(i);
             de.tick(this.stepSize);
-            i := i + 1;
+            i = i + 1;
         end
         return i;
     end
 
     Int execute(Int steps)
-        Int i := 1;
+        Int i = 1;
         while( i <= steps ) do
             this.round();
-            i := i+1;
+            i = i+1;
         end
         return i;
     end
@@ -61,25 +61,25 @@ class PredatorOutPort extends OutPort<Double>(Cont[in Double x, out Double y] pr
     override Double get() return this.predator.y; end
 end
 class PreyInPort extends InPort<Double>(Cont[in Double y, out Double x] prey)
-    override Boolean write(Double t) this.prey.y := t; return True; end
+    override Boolean write(Double t) this.prey.y = t; return True; end
 end
 class PredatorInPort extends InPort<Double>(Cont[in Double x, out Double y] predator)
-    override Boolean write(Double t) print(t); this.predator.x := t; return True; end
+    override Boolean write(Double t) print(t); this.predator.x = t; return True; end
 end
 
 main
-    Cont[in Double y, out Double x] prey := simulate("examples/SimulationDemo/Prey.fmu", y := 10);
-    Cont[in Double x, out Double y] predator := simulate("examples/SimulationDemo/Predator.fmu", x := 10);
-    PreyOutPort preyOut := new PreyOutPort(prey);
-    PredatorOutPort predOut := new PredatorOutPort(predator);
-    PreyInPort preyIn := new PreyInPort(prey);
-    PredatorInPort predIn := new PredatorInPort(predator);
-    Connection c1 := new ImplConnection(preyOut, predIn);
-    Connection c2 := new ImplConnection(predOut, preyIn);
-    List<Cont[]> fmus := new List<Cont[]>(prey, null);
-    fmus := new List<Cont[]>(predator, fmus);
-    List<Connection> cons := new List<Connection>(c1, null);
-    cons := new List<Connection>(c2, cons);
-    CoSim sim := new CoSim(cons, fmus, 0.2);
+    Cont[in Double y, out Double x] prey = simulate("examples/SimulationDemo/Prey.fmu", y = 10);
+    Cont[in Double x, out Double y] predator = simulate("examples/SimulationDemo/Predator.fmu", x = 10);
+    PreyOutPort preyOut = new PreyOutPort(prey);
+    PredatorOutPort predOut = new PredatorOutPort(predator);
+    PreyInPort preyIn = new PreyInPort(prey);
+    PredatorInPort predIn = new PredatorInPort(predator);
+    Connection c1 = new ImplConnection(preyOut, predIn);
+    Connection c2 = new ImplConnection(predOut, preyIn);
+    List<Cont[]> fmus = new List<Cont[]>(prey, null);
+    fmus = new List<Cont[]>(predator, fmus);
+    List<Connection> cons = new List<Connection>(c1, null);
+    cons = new List<Connection>(c2, cons);
+    CoSim sim = new CoSim(cons, fmus, 0.2);
     sim.execute(200);
 end

--- a/src/test/resources/TwoThreeTree.smol
+++ b/src/test/resources/TwoThreeTree.smol
@@ -7,27 +7,27 @@ class Node<S>(Pair<Int, S> dataL,
                   Node<S> childR,
                   Node<S> parent)
     Node<S> add(Pair<Int, S> kv)
-        Node<S> res := null;
-        if(this.childL = null) then //this is a leaf
-            if(this.dataL = null)  then this.dataL := kv;
+        Node<S> res = null;
+        if(this.childL == null) then //this is a leaf
+            if(this.dataL == null)  then this.dataL = kv;
             else
-                if (this.dataR = null) then
-                     if (this.dataL.key <= kv.key) then this.dataR := kv;
+                if (this.dataR == null) then
+                     if (this.dataL.key <= kv.key) then this.dataR = kv;
                      else
-                        this.dataR := this.dataL;
-                        this.dataL := kv;
+                        this.dataR = this.dataL;
+                        this.dataL = kv;
                      end
                 else
-                    res := this.createNew(kv);
+                    res = this.createNew(kv);
                 end
             end
         else                    //this is an internal node
-            if(kv.key <= this.dataL.key) then res := this.childL.add(kv);
+            if(kv.key <= this.dataL.key) then res = this.childL.add(kv);
             else
-                if(this.dataR = null) then res := this.childM.add(kv); //this is a 2-node
+                if(this.dataR == null) then res = this.childM.add(kv); //this is a 2-node
                 else                                        //this is a 3-node
-                    if(kv.key <= this.dataR.key) then res := this.childM.add(kv);
-                    else res := this.childR.add(kv);
+                    if(kv.key <= this.dataR.key) then res = this.childM.add(kv);
+                    else res = this.childR.add(kv);
                     end
                 end
              end
@@ -38,133 +38,133 @@ class Node<S>(Pair<Int, S> dataL,
 
     Node<S> createNew(Pair<Int, S>kv)
         //find middle
-        Pair<Int, S> middle := null;
-        Node<S> left := null;
-        Node<S> right := null;
+        Pair<Int, S> middle = null;
+        Node<S> left = null;
+        Node<S> right = null;
         if(kv.key <= this.dataL.key) then
-            middle := this.dataL;
-            left := new Node<S>(kv, null, null, null, null, null);
-            right := new Node<S>(this.dataR, null, null, null, null, null);
+            middle = this.dataL;
+            left = new Node<S>(kv, null, null, null, null, null);
+            right = new Node<S>(this.dataR, null, null, null, null, null);
         else
             if (kv.key >= this.dataR.key) then
-                middle := this.dataR;
-                left := new Node<S>(this.dataL, null, null, null, null, null);
-                right := new Node<S>(kv, null, null, null, null, null);
+                middle = this.dataR;
+                left = new Node<S>(this.dataL, null, null, null, null, null);
+                right = new Node<S>(kv, null, null, null, null, null);
             else
-                middle := kv;
-                left := new Node<S>(this.dataL, null, null, null, null, null);
-                right := new Node<S>(this.dataR, null, null, null, null, null);
+                middle = kv;
+                left = new Node<S>(this.dataL, null, null, null, null, null);
+                right = new Node<S>(this.dataR, null, null, null, null, null);
             end
          end
-        Node<S> newTop := this.repairOrReroot(middle, left, right);
+        Node<S> newTop = this.repairOrReroot(middle, left, right);
         return newTop;
     end
 
     Node<S> repair(Node<S> left, Pair<Int, S> middle, Node<S> right, Node<S> from)
-        Node<S> res := null;
-        if(this.dataR = null) then  //internal 2-node
-            if(from = this.childL) then
-                this.dataR := this.dataL;
-                this.dataL := middle;
-                this.childR := this.childM;
-                this.childM := right;
-                this.childL := left;
-                right.parent := this;
-                left.parent := this;
+        Node<S> res = null;
+        if(this.dataR == null) then  //internal 2-node
+            if(from == this.childL) then
+                this.dataR = this.dataL;
+                this.dataL = middle;
+                this.childR = this.childM;
+                this.childM = right;
+                this.childL = left;
+                right.parent = this;
+                left.parent = this;
             else
-                this.dataR := middle;
-                this.childR := right;
-                this.childM := left;
-                right.parent := this;
-                left.parent := this;
+                this.dataR = middle;
+                this.childR = right;
+                this.childM = left;
+                right.parent = this;
+                left.parent = this;
             end
             return this;
         else                        //internal 3-node
-            Node<S> newLeft := null;
-            Node<S> newRight := null;
-            if(from = this.childL) then
-                 newLeft := new Node<S>(middle, null, left, right, null, null);
-                 left.parent := newLeft;
-                 right.parent := newLeft;
-                 newRight := new Node<S>(this.dataR, null, this.childM, this.childR, null, null);
-                 this.childM.parent := newRight;
-                 this.childR.parent := newRight;
+            Node<S> newLeft = null;
+            Node<S> newRight = null;
+            if(from == this.childL) then
+                 newLeft = new Node<S>(middle, null, left, right, null, null);
+                 left.parent = newLeft;
+                 right.parent = newLeft;
+                 newRight = new Node<S>(this.dataR, null, this.childM, this.childR, null, null);
+                 this.childM.parent = newRight;
+                 this.childR.parent = newRight;
             else
-                if(from = this.childM) then
-                     newLeft := new Node<S>(this.dataL, null, this.childL, left, null, null);
-                     this.childL.parent := newLeft;
-                     left.parent := newLeft;
-                     newRight := new Node<S>(this.dataR, null, right, this.childR, null, null);
-                     right.parent := newRight;
-                     this.childR.parent := newRight;
+                if(from == this.childM) then
+                     newLeft = new Node<S>(this.dataL, null, this.childL, left, null, null);
+                     this.childL.parent = newLeft;
+                     left.parent = newLeft;
+                     newRight = new Node<S>(this.dataR, null, right, this.childR, null, null);
+                     right.parent = newRight;
+                     this.childR.parent = newRight;
                 else
-                     newLeft := new Node<S>(this.dataL, null, this.childL, this.childM, null, null);
-                     this.childL.parent := newLeft;
-                     this.childM.parent := newLeft;
-                     newRight := new Node<S>(middle, null, left, right, null, null);
-                     left.parent := newRight;
-                     right.parent := newRight;
+                     newLeft = new Node<S>(this.dataL, null, this.childL, this.childM, null, null);
+                     this.childL.parent = newLeft;
+                     this.childM.parent = newLeft;
+                     newRight = new Node<S>(middle, null, left, right, null, null);
+                     left.parent = newRight;
+                     right.parent = newRight;
                 end
             end
-        res := this.repairOrReroot(this.dataR, newLeft, newRight);
+        res = this.repairOrReroot(this.dataR, newLeft, newRight);
         return res;
         end
     end
 
     Node<S> repairOrReroot(Pair<Int, S> middle, Node<S> left, Node<S> right)
-        Node<S> newTop := null;
-        if(this.parent = null) then //root
-            newTop := new Node<S>(middle, null, left, right, null, null);
-            left.parent := newTop;
-            right.parent := newTop;
+        Node<S> newTop = null;
+        if(this.parent == null) then //root
+            newTop = new Node<S>(middle, null, left, right, null, null);
+            left.parent = newTop;
+            right.parent = newTop;
         else
-            newTop := this.parent.repair(left, middle, right, this);
-            this.parent := null;
+            newTop = this.parent.repair(left, middle, right, this);
+            this.parent = null;
         end
         return newTop;
     end
     S retrieve(Int k)
-       S res := null;
-       if(this.dataL = null) then res := null; return res; end
-       if(k = this.dataL.key) then res := this.dataL.value; return res; end
-       if(k <= this.dataL.key) then res := this.childL.retrieve(k); return res; end
-       if(this.dataR = null) then res := this.childM.retrieve(k); return res; end
-       if(k = this.dataR.key) then res := this.dataR.value; return res; end
-       if(k <= this.dataR.key) then res := this.childM.retrieve(k); return res; end
-       res := this.childR.retrieve(k);
+       S res = null;
+       if(this.dataL == null) then res = null; return res; end
+       if(k == this.dataL.key) then res = this.dataL.value; return res; end
+       if(k <= this.dataL.key) then res = this.childL.retrieve(k); return res; end
+       if(this.dataR == null) then res = this.childM.retrieve(k); return res; end
+       if(k == this.dataR.key) then res = this.dataR.value; return res; end
+       if(k <= this.dataR.key) then res = this.childM.retrieve(k); return res; end
+       res = this.childR.retrieve(k);
        return res;
     end
 end
 
 class Tree<P>(Node<P> root)
     Int add(Pair<Int, P> kv)
-        Node<P> res := this.root.add(kv);
-        if(res <> null) then this.root := res; end
+        Node<P> res = this.root.add(kv);
+        if(res != null) then this.root = res; end
         return 0;
     end
     P retrieve(Int k)
-       P res := this.root.retrieve(k);
+       P res = this.root.retrieve(k);
        return res;
     end
 end
 
 class  Wrap<Z>(Tree<Z> ttt, Int key)
     rule Z lookup()
-        Z v := this.ttt.retrieve(this.key);
+        Z v = this.ttt.retrieve(this.key);
         return v;
     end
 end
 
 main
-    Node<String> root := new Node<String>(null, null, null, null, null, null);
-    Tree<String> tree := new Tree<String>(root);
-    Pair<Int, String> pair1 := new Pair<Int, String>(1,"a");
-    Pair<Int, String> pair2 := new Pair<Int, String>(2,"b");
-    Pair<Int, String> pair3 := new Pair<Int, String>(3,"c");
-    Pair<Int, String> pair4 := new Pair<Int, String>(4,"d");
-    Pair<Int, String> pair5 := new Pair<Int, String>(5,"e");
-    Pair<Int, String> pair6 := new Pair<Int, String>(6,"f");
-    Pair<Int, String> pair7 := new Pair<Int, String>(7,"g");
+    Node<String> root = new Node<String>(null, null, null, null, null, null);
+    Tree<String> tree = new Tree<String>(root);
+    Pair<Int, String> pair1 = new Pair<Int, String>(1,"a");
+    Pair<Int, String> pair2 = new Pair<Int, String>(2,"b");
+    Pair<Int, String> pair3 = new Pair<Int, String>(3,"c");
+    Pair<Int, String> pair4 = new Pair<Int, String>(4,"d");
+    Pair<Int, String> pair5 = new Pair<Int, String>(5,"e");
+    Pair<Int, String> pair6 = new Pair<Int, String>(6,"f");
+    Pair<Int, String> pair7 = new Pair<Int, String>(7,"g");
     tree.add(pair3);
     tree.add(pair2);
     tree.add(pair1);
@@ -173,9 +173,9 @@ main
     tree.add(pair5);
     tree.add(pair6);
 
-    Wrap<String> ww := new Wrap<String>(tree, 1);
-    //res := ww.lookup(); //query SELECT ?x WHERE { ?x a domain:TwoNode }
-    List<String> res := access("SELECT ?obj WHERE {?sth prog:Wrap_lookup_builtin_res ?obj}");
+    Wrap<String> ww = new Wrap<String>(tree, 1);
+    //res = ww.lookup(); //query SELECT ?x WHERE { ?x a domain:TwoNode }
+    List<String> res = access("SELECT ?obj WHERE {?sth prog:Wrap_lookup_builtin_res ?obj}");
     print(res);
     breakpoint;
     print("done");

--- a/src/test/resources/destroy.smol
+++ b/src/test/resources/destroy.smol
@@ -3,13 +3,13 @@ class A(Int i1) end
 
 main
 
-    A a := new A(1);
-    List<A> list := access("SELECT ?obj WHERE {?obj a prog:A}");
+    A a = new A(1);
+    List<A> list = access("SELECT ?obj WHERE {?obj a prog:A}");
     print(list);
     print(list.content);
     destroy(a);
     print(list.content);
-    List<A> list2 := access("SELECT ?obj WHERE {?obj a prog:A}");
+    List<A> list2 = access("SELECT ?obj WHERE {?obj a prog:A}");
     breakpoint;
     print(list);
 end

--- a/src/test/resources/double.smol
+++ b/src/test/resources/double.smol
@@ -1,8 +1,8 @@
 class  DList<T> (DList<T> next, T content, DList<T> previous)
    DList<T> append(DList<T> node)
-      if this.next = null then
-         this.next := node;
-         node.previous := this;
+      if this.next == null then
+         this.next = node;
+         node.previous = this;
       else
         this.next.append(node);
       end
@@ -10,54 +10,54 @@ class  DList<T> (DList<T> next, T content, DList<T> previous)
    end
 
    DList<T> insert_after(DList<T> node)
-        node.next := this.next;
-        node.previous := this;
-        if this.next <> null then
-            this.next.previous := node;
-            this.next := node;
+        node.next = this.next;
+        node.previous = this;
+        if this.next != null then
+            this.next.previous = node;
+            this.next = node;
         else skip; end
         return this;
    end
 
 
    DList<T> remove()
-        if this.next <> null then
-            this.next.previous := this.previous;
+        if this.next != null then
+            this.next.previous = this.previous;
         else skip; end
-        if this.previous <> null then
-            this.previous.next := this.next;
+        if this.previous != null then
+            this.previous.next = this.next;
         else skip; end
-        this.next := null;
-        this.previous := null;
+        this.next = null;
+        this.previous = null;
         return this;
    end
 
 
    DList<T> remove_unclean()
-        if this.next <> null then
-            this.next.previous := this.previous;
+        if this.next != null then
+            this.next.previous = this.previous;
         else skip; end
-        if this.previous <> null then
-            this.previous.next := this.next;
+        if this.previous != null then
+            this.previous.next = this.next;
         else skip; end
-        this.next := null;
+        this.next = null;
         return this;
    end
 end
 
 
 main
-  DList<Int> a := new DList<Int>(null, 1, null);
-  DList<Int> b := new DList<Int>(null, 2, null);
-  DList<Int> c := new DList<Int>(null, 4, null);
-  DList<Int> d := new DList<Int>(null, 3, null);
+  DList<Int> a = new DList<Int>(null, 1, null);
+  DList<Int> b = new DList<Int>(null, 2, null);
+  DList<Int> c = new DList<Int>(null, 4, null);
+  DList<Int> d = new DList<Int>(null, 3, null);
   a.append(b);
   a.append(c);
   b.insert_after(d);
   c.remove();
   breakpoint;
   print(a.next.next.content);
-  Boolean val := validate("examples/double.ttl");
+  Boolean val = validate("examples/double.ttl");
   breakpoint;
   print(val);
 end

--- a/src/test/resources/models.smol
+++ b/src/test/resources/models.smol
@@ -1,13 +1,13 @@
 class C() models "a domain:A."; end
 
 main
-  C c := new C() models "a domain:B.";
-  c := new C();
-  c := new C();
-  List<C> test1 := member("<domain:models> some <domain:B>");
-  List<C> test2 := member("<domain:models> some <domain:A>");
-  Int l1 := test1.length();
-  Int l2 := test2.length();
+  C c = new C() models "a domain:B.";
+  c = new C();
+  c = new C();
+  List<C> test1 = member("<domain:models> some <domain:B>");
+  List<C> test2 = member("<domain:models> some <domain:A>");
+  Int l1 = test1.length();
+  Int l2 = test2.length();
   breakpoint;
   breakpoint;
 end

--- a/src/test/resources/overload.smol
+++ b/src/test/resources/overload.smol
@@ -4,92 +4,92 @@ class Task(String name) end
 
 class Server(List<Task> taskList)
     Task excessive()
-        Task ret := this.taskList.content;
-        this.taskList := this.taskList.next;
+        Task ret = this.taskList.content;
+        this.taskList = this.taskList.next;
         return ret;
     end
     Int add(Task task)
-        this.taskList := new List<Task>(task, this.taskList);
+        this.taskList = new List<Task>(task, this.taskList);
         return 0;
     end
 end
 class Scheduler(List<Server> serverList)
     Int reschedule()
-        List<Server> over := access("SELECT ?obj WHERE{?obj a domain:Overloaded }");
+        List<Server> over = access("SELECT ?obj WHERE{?obj a domain:Overloaded }");
         //breakpoint;
-        List<Task> tasks := this.collectExcessiveTasks(over);
+        List<Task> tasks = this.collectExcessiveTasks(over);
         //breakpoint;
-        tasks := this.rescheduleTasks(tasks, over);
+        tasks = this.rescheduleTasks(tasks, over);
         //breakpoint;
-        while tasks <> null do
-            List<Task> l := new List<Task>(tasks.content, null);
-            Server n := new Server(l);
-            this.serverList := new List<Server>(n, this.serverList);
-            tasks := tasks.next;
+        while tasks != null do
+            List<Task> l = new List<Task>(tasks.content, null);
+            Server n = new Server(l);
+            this.serverList = new List<Server>(n, this.serverList);
+            tasks = tasks.next;
         end
         return 0;
     end
 
     List<Task> collectExcessiveTasks(List<Server> overloaded)
-       List<Server> plats := this.serverList;
-       List<Task> exc := null;
-       while plats <> null do
-            Boolean b := overloaded.contains(plats.content);
+       List<Server> plats = this.serverList;
+       List<Task> exc = null;
+       while plats != null do
+            Boolean b = overloaded.contains(plats.content);
             //breakpoint;
             if b then
-                Task localExc := plats.content.excessive();
-                exc := new List<Task>(localExc, exc);
+                Task localExc = plats.content.excessive();
+                exc = new List<Task>(localExc, exc);
             end
-            plats := plats.next;
+            plats = plats.next;
        end
        return exc;
     end
 
     List<Task> rescheduleTasks(List<Task> tasks, List<Server> overloaded)
-       List<Server> plats := this.serverList;
-       while plats <> null do
-            Boolean b := overloaded.contains(plats.content);
+       List<Server> plats = this.serverList;
+       while plats != null do
+            Boolean b = overloaded.contains(plats.content);
             if b then
                 skip;
             else
                 plats.content.add(tasks.content);
-                tasks := tasks.next;
+                tasks = tasks.next;
             end
-            plats := plats.next;
-            if tasks = null then return null; end
+            plats = plats.next;
+            if tasks == null then return null; end
        end
        return tasks;
     end
 end
 
 main
-    Task task1 := new Task("t1");
-    Task task2 := new Task("t2");
-    Task task3 := new Task("t3");
-    Task task4 := new Task("t4");
-    Task task5 := new Task("t5");
-    Task task6 := new Task("t6");
+    Task task1 = new Task("t1");
+    Task task2 = new Task("t2");
+    Task task3 = new Task("t3");
+    Task task4 = new Task("t4");
+    Task task5 = new Task("t5");
+    Task task6 = new Task("t6");
 
-    List<Task> l1 := new List<Task>(task1, null);
-    List<Task> l2 := new List<Task>(task2, null);
-    List<Task> l3 := new List<Task>(task3, l2);
-    List<Task> l4 := new List<Task>(task4, null);
-    List<Task> l5 := new List<Task>(task5, l4);
-    List<Task> l6 := new List<Task>(task6, l5);
+    List<Task> l1 = new List<Task>(task1, null);
+    List<Task> l2 = new List<Task>(task2, null);
+    List<Task> l3 = new List<Task>(task3, l2);
+    List<Task> l4 = new List<Task>(task4, null);
+    List<Task> l5 = new List<Task>(task5, l4);
+    List<Task> l6 = new List<Task>(task6, l5);
 
-    Server dummy := new Server(null);
-    Server server1 := new Server(l1);
-    Server server2 := new Server(l3);
-    Server server3 := new Server(l6);
-    List<Server> sl1 := new List<Server>(server3, null);
-    List<Server> sl2 := new List<Server>(server2, sl1);
-    List<Server> sl3 := new List<Server>(server1, sl2);
+    Server dummy = new Server(null);
+    Server server1 = new Server(l1);
+    Server server2 = new Server(l3);
+    Server server3 = new Server(l6);
+    List<Server> sl1 = new List<Server>(server3, null);
+    List<Server> sl2 = new List<Server>(server2, sl1);
+    List<Server> sl3 = new List<Server>(server1, sl2);
 
-    Scheduler sch := new Scheduler(sl3);
+    Scheduler sch = new Scheduler(sl3);
     breakpoint;
-    List<Server> pre := access("SELECT ?obj WHERE{?obj a domain:Overloaded }");
+    List<Server> pre = access("SELECT ?obj WHERE{?obj a domain:Overloaded }");
     sch.reschedule();
-    List<Server> post := access("SELECT ?obj WHERE{?obj a domain:Overloaded }");
+    List<Server> post = access("SELECT ?obj WHERE{?obj a domain:Overloaded }");
     breakpoint;
     print(sch);
 end

--- a/src/test/resources/persons.smol
+++ b/src/test/resources/persons.smol
@@ -19,8 +19,8 @@ end
 
 main
     // The first Person
-    Person annie := new Person(13025213498, "Annie", 1952, 1.75, True);
-    Person bernie := new Person(13025213598, "Bernie", 1952, 1.83, False);
-    Marriage m1 := new Marriage(annie, bernie);
+    Person annie = new Person(13025213498, "Annie", 1952, 1.75, True);
+    Person bernie = new Person(13025213598, "Bernie", 1952, 1.83, False);
+    Marriage m1 = new Marriage(annie, bernie);
 
 end

--- a/src/test/resources/poly.smol
+++ b/src/test/resources/poly.smol
@@ -6,14 +6,14 @@ end
 
 class D extends C ()
     override Int m()
-        Int s := super();
-        C v := new D();
+        Int s = super();
+        C v = new D();
         return 2 + s ;
     end
 end
 
 main
-    C v := new D();
-    Int w := v.m();
+    C v = new D();
+    Int w = v.m();
     print(w);
 end

--- a/src/test/resources/scene.smol
+++ b/src/test/resources/scene.smol
@@ -6,12 +6,12 @@ end
 
 class Rectangle(Scene scene, Int w, Int h, String name)
     rule Int area()
-        Int s := this.scene.getScale();
+        Int s = this.scene.getScale();
         return s*this.w*this.h;
     end
 end
 
 main
-    Scene sc := new Scene(2);
-    Rectangle r := new Rectangle(sc, 5, 1, "rect1");
+    Scene sc = new Scene(2);
+    Rectangle r = new Rectangle(sc, 5, 1, "rect1");
 end

--- a/src/test/resources/test_assign.smol
+++ b/src/test/resources/test_assign.smol
@@ -4,55 +4,55 @@ class Wrapper<U>(U content) end
 
 class Test()
   Int assignSuccess1()
-    C c := new D(1, null);
-    C c2 := new D(1, c);
-    C c3 := new D(1, 1);
+    C c = new D(1, null);
+    C c2 = new D(1, c);
+    C c3 = new D(1, 1);
     return 0;
   end
 
   Int opsuccess()
-    Boolean b1 := True;
-    Boolean b2 := False;
-    Double d1 := 1.0;
-    Double d2 := 2.0;
-    if(!(d1 <> d2) & b2) then d2 := d1/d2; end
-    if(!(d1 > d2) | b1 | (d1 < d2)) then d2 := d1/d2; end
+    Boolean b1 = True;
+    Boolean b2 = False;
+    Double d1 = 1.0;
+    Double d2 = 2.0;
+    if(!(d1 != d2) & b2) then d2 = d1/d2; end
+    if(!(d1 > d2) | b1 | (d1 < d2)) then d2 = d1/d2; end
     return 0;
   end
 
   Int opfail()
-    Boolean b1 := True;
-    Boolean b2 := False;
-    Double d1 := 1.0;
-    Double d2 := 2.0;
-    Int i1 := 1;
-    if(!d1) then d2 := d1/d2; end
-    if(d1 <> b1) then d2 := d1/d2; end
-    if(b2 < b1) then d2 := i1/d2; end
+    Boolean b1 = True;
+    Boolean b2 = False;
+    Double d1 = 1.0;
+    Double d2 = 2.0;
+    Int i1 = 1;
+    if(!d1) then d2 = d1/d2; end
+    if(d1 != b1) then d2 = d1/d2; end
+    if(b2 < b1) then d2 = i1/d2; end
     return 0;
   end
 
   Int assignSuccess2()
-    C c := new D(1, null);
-    Wrapper<C> v := new Wrapper<C>(c);
-    D d := new D(1, null);
-    Wrapper<C> w := new Wrapper<D>(d);
+    C c = new D(1, null);
+    Wrapper<C> v = new Wrapper<C>(c);
+    D d = new D(1, null);
+    Wrapper<C> w = new Wrapper<D>(d);
     return 0;
   end
 
   Int fail1()
-    D d := new C(1);
+    D d = new C(1);
     return 0;
   end
 
   Int fail2()
-    C c := new C("hi");
+    C c = new C("hi");
     return 0;
   end
 
   Int fail3()
-    C c := new C(1);
-    Wrapper<D> w := new Wrapper<C>(c);
+    C c = new C(1);
+    Wrapper<D> w = new Wrapper<C>(c);
     return 0;
   end
 
@@ -61,17 +61,17 @@ class Test()
   end
 
   Int fail5()
-    if( 1 = "hi") then skip; end
+    if( 1 == "hi") then skip; end
     return 0;
   end
 
   Int fail6()
-    while( 1 = "hi") do skip; end
+    while( 1 == "hi") do skip; end
     return 0;
   end
 
   Int fail7()
-    Int i := "hi";
+    Int i = "hi";
     return 0;
   end
 end
@@ -79,30 +79,30 @@ end
 
 class TestGen<A,B> (A a, B b, Wrapper<A> wa, Wrapper<B> wb)
     Int success()
-        this.a := this.wa.content;
-        this.b := this.wb.content;
-        this.wa := new Wrapper<A>(this.a);
-        this.wb := new Wrapper<B>(this.b);
+        this.a = this.wa.content;
+        this.b = this.wb.content;
+        this.wa = new Wrapper<A>(this.a);
+        this.wb = new Wrapper<B>(this.b);
         return 0;
     end
 
     Int fail1()
-        this.a := this.wb.content;
+        this.a = this.wb.content;
         return 0;
     end
 
     Int fail2()
-        this.wb := new Wrapper<A>(this.a);
+        this.wb = new Wrapper<A>(this.a);
         return 0;
     end
 
     Int fail3()
-        this.a := this.b;
+        this.a = this.b;
         return 0;
     end
 
     Int fail4()
-        this.wa := this.b;
+        this.wa = this.b;
         return 0;
     end
 end

--- a/src/test/resources/test_call.smol
+++ b/src/test/resources/test_call.smol
@@ -9,10 +9,10 @@ class Wrapper<U>(U content) end
 class Test(C c, D d, Wrapper<C> cw, Wrapper<D> dw)
 
     Int success()
-        Int i := this.cw.content.m1(1);
-        Object o := this.dw.content.m2(1);
-        o := i;
-        D d := new D(i, o);
+        Int i = this.cw.content.m1(1);
+        Object o = this.dw.content.m2(1);
+        o = i;
+        D d = new D(i, o);
         d.m2(i);
         return 1;
     end
@@ -22,7 +22,7 @@ class Test(C c, D d, Wrapper<C> cw, Wrapper<D> dw)
     end
 
     Int fail2() //no return
-        if( 1 = 2 ) then
+        if( 1 == 2 ) then
             skip;
         else
             return 1;
@@ -30,27 +30,27 @@ class Test(C c, D d, Wrapper<C> cw, Wrapper<D> dw)
     end
 
     Int fail3() //wrong method
-        Int i := this.cw.content.m2(1);
+        Int i = this.cw.content.m2(1);
         return 1;
     end
 
     Int fail4() //method does not exist
-        Int i := this.cw.content.m3(1);
+        Int i = this.cw.content.m3(1);
         return 1;
     end
 
     Int fail5() //wrong parameter
-        Int i := this.cw.content.m1(this.d);
+        Int i = this.cw.content.m1(this.d);
         return 1;
     end
 
     Int fail6() //wrong number of parameters
-        Int i := this.cw.content.m1(1,1);
+        Int i = this.cw.content.m1(1,1);
         return 1;
     end
 
     Int fail7() //wrong return type
-        D i := this.cw.content.m1(1);
+        D i = this.cw.content.m1(1);
         return 1;
     end
 end

--- a/src/test/resources/test_fmu.smol
+++ b/src/test/resources/test_fmu.smol
@@ -1,96 +1,96 @@
 class SuccessClass()
     Int start()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[in Double ra, in Double rb ] fmu2 := simulate("src/test/resources/adder.fmu");
-        Cont[in Double rb, out Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
-        Cont[] fmu4 := simulate("src/test/resources/adder.fmu");
-        Cont[in Double ra, in Double rb, out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb ] fmu2 = simulate("src/test/resources/adder.fmu");
+        Cont[in Double rb, out Double rc] fmu3 = simulate("src/test/resources/adder.fmu");
+        Cont[] fmu4 = simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu5 = simulate("src/test/resources/adder.fmu", ra = 0.0);
         return 1;
     end
 
     Int assign()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[in Double ra, in Double rb] fmu2 := simulate("src/test/resources/adder.fmu");
-        Cont[in Double rb, out Double rc] fmu3 := simulate("src/test/resources/adder.fmu");
-        Cont[] fmu4 := simulate("src/test/resources/adder.fmu");
-        Cont[in Double ra, in Double rb, out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", ra := 0.0);
-        fmu2 := fmu1;
-        fmu3 := fmu1;
-        fmu4 := fmu1;
-        fmu4 := fmu2;
-        fmu4 := fmu3;
-        fmu1 := fmu5;
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb] fmu2 = simulate("src/test/resources/adder.fmu");
+        Cont[in Double rb, out Double rc] fmu3 = simulate("src/test/resources/adder.fmu");
+        Cont[] fmu4 = simulate("src/test/resources/adder.fmu");
+        Cont[in Double ra, in Double rb, out Double rc] fmu5 = simulate("src/test/resources/adder.fmu", ra = 0.0);
+        fmu2 = fmu1;
+        fmu3 = fmu1;
+        fmu4 = fmu1;
+        fmu4 = fmu2;
+        fmu4 = fmu3;
+        fmu1 = fmu5;
         return 1;
     end
 
     Int portTest()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Double dd := fmu1.port("rc");
-        fmu1.port("ra") := 2.0;
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        Double dd = fmu1.port("rc");
+        fmu1.port("ra") = 2.0;
         return 1;
     end
 
     Int fieldfail1()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Double g := fmu1.ra;
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        Double g = fmu1.ra;
     end
     Int fieldfail2()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        fmu1.rc := 1.0;
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        fmu1.rc = 1.0;
     end
     Int fieldfail3()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        fmu1.rc := 1;
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        fmu1.rc = 1;
     end
     Int fieldfail4()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        fmu1.rd := 1;
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        fmu1.rd = 1;
     end
     Int fieldfail5()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Double dd := fmu1.rd;
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        Double dd = fmu1.rd;
     end
     Int fieldfail6()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Double dd := fmu1.port("rd");
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        Double dd = fmu1.port("rd");
     end
     Int extra(String str, Double param)
-        Cont[] fmu4 := simulate("src/test/resources/adder.fmu");
-        fmu4.role := str;
-        fmu4.pseudoOffset := param;
-        String read := fmu4.role;
-        Double pseudoOffset := fmu4.pseudoOffset;
+        Cont[] fmu4 = simulate("src/test/resources/adder.fmu");
+        fmu4.role = str;
+        fmu4.pseudoOffset = param;
+        String read = fmu4.role;
+        Double pseudoOffset = fmu4.pseudoOffset;
         return 0;
     end
 end
 
 class FailClass()
     Int fail1()
-        Cont[in Int ra, in Int rb, out Int rc] fmu1 := simulate("src/test/resources/adder.fmu"); //wrong type
+        Cont[in Int ra, in Int rb, out Int rc] fmu1 = simulate("src/test/resources/adder.fmu"); //wrong type
         return 1;
     end
     Int fail2()
-        Cont[in Double rc, out Double ra, out Double rb] fmu5 := simulate("src/test/resources/adder.fmu"); //wrong order
+        Cont[in Double rc, out Double ra, out Double rb] fmu5 = simulate("src/test/resources/adder.fmu"); //wrong order
         return 1;
     end
     Int fail3()
-        Cont[in Double ra, in Double rb, out Double rc] fmu5 := simulate("src/test/resources/adder.fmu", rc := 0.0); //inits output
+        Cont[in Double ra, in Double rb, out Double rc] fmu5 = simulate("src/test/resources/adder.fmu", rc = 0.0); //inits output
         return 1;
     end
     Int fail4()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[in Int ia, in Int ib, out Int ic] fmu2 := simulate("src/test/resources/adder.fmu");
-        fmu2 := fmu1;
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        Cont[in Int ia, in Int ib, out Int ic] fmu2 = simulate("src/test/resources/adder.fmu");
+        fmu2 = fmu1;
         return 1;
     end
     Int fail5()
-        Cont[in Double ra, in Double rb, out Double rc] fmu1 := simulate("src/test/resources/adder.fmu");
-        Cont[] fmu2 := simulate("src/test/resources/adder.fmu");
-        fmu1 := fmu2;
+        Cont[in Double ra, in Double rb, out Double rc] fmu1 = simulate("src/test/resources/adder.fmu");
+        Cont[] fmu2 = simulate("src/test/resources/adder.fmu");
+        fmu1 = fmu2;
         return 1;
     end
     Int fail6()
-        Cont[in Int rb, out Int rc] fmu1 := simulate("src/test/resources/adder.fmu");
+        Cont[in Int rb, out Int rc] fmu1 = simulate("src/test/resources/adder.fmu");
         return 1;
     end
 end

--- a/src/test/resources/test_override.smol
+++ b/src/test/resources/test_override.smol
@@ -9,28 +9,28 @@ class Success1 extends E ()
     override C m(C c) return c; end
 end
 class Success2 extends E ()
-    override C m(C c) C ret := super(c); return ret; end
+    override C m(C c) C ret = super(c); return ret; end
 end
 class Fail1 extends E () //lacks modifier
-    C m(C c) C ret := super(c); return ret; end
+    C m(C c) C ret = super(c); return ret; end
 end
 class Fail2 extends E () //changes signature
-    override C m(E c) C ret := super(c); return ret; end
+    override C m(E c) C ret = super(c); return ret; end
 end
 class Fail3 extends E () //changes signature
-    override C m(C d) C ret := super(d); return ret; end
+    override C m(C d) C ret = super(d); return ret; end
 end
 class Fail4 extends E () //changes signature
-    override C m(C c, D d) C ret := super(c); return ret; end
+    override C m(C c, D d) C ret = super(c); return ret; end
 end
 class Fail5 extends E () //wrong modifier
-    override C n(C c) C ret := super(c); return ret; end
+    override C n(C c) C ret = super(c); return ret; end
 end
 class Fail6 extends E () //ill-typed super call
-    override C m(C c) C ret := super(1); return ret; end
+    override C m(C c) C ret = super(1); return ret; end
 end
 class Fail7 extends E () //ill-typed super call
-    override C m(C c) C ret := super(null, null); return ret; end
+    override C m(C c) C ret = super(null, null); return ret; end
 end
 
 main

--- a/src/test/resources/type_query.smol
+++ b/src/test/resources/type_query.smol
@@ -11,41 +11,41 @@ class E extends C () end
 class Test()
 
     Int mSuccess1()
-      List<C> l := access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
+      List<C> l = access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
       return 1;
     end
 
     Int mSuccess2()
-      List<A> l := access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
+      List<A> l = access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
       return 1;
     end
 
     Int mSuccess3()
-      List<Object> l := access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
+      List<Object> l = access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
       return 1;
     end
 
     Int mSuccess4()
-      List<Object> l := access("SELECT ?obj WHERE {?obj prog:C_aCB [ prog:B_aB [ prog:A_sealing 1 ]]}");
+      List<Object> l = access("SELECT ?obj WHERE {?obj prog:C_aCB [ prog:B_aB [ prog:A_sealing 1 ]]}");
       return 1;
     end
 
     Int mSuccess5()
-      List<Object> l := access("SELECT ?obj WHERE {?obj prog:C_aCB [ prog:B_aB [ prog:A_sealing %1 ]]}", 1);
+      List<Object> l = access("SELECT ?obj WHERE {?obj prog:C_aCB [ prog:B_aB [ prog:A_sealing %1 ]]}", 1);
       return 1;
     end
 
     Int mFail1()
-      List<B> l := access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
+      List<B> l = access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
       return 1;
     end
 
    Int mFail2()
-     List<E> ld := access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
+     List<E> ld = access("SELECT ?obj WHERE {?obj prog:C_aCB ?b. ?b prog:B_aB ?a. ?a prog:A_sealing 1 }");
      return 1;
    end
    Int mFail3()
-     List<List<String>> ld := access("SELECT ?obj WHERE {?obj prog:List_head %1}", 42);
+     List<List<String>> ld = access("SELECT ?obj WHERE {?obj prog:List_head %1}", 42);
      return 1;
    end
 end
@@ -53,7 +53,7 @@ end
 class F(Int i)
      rule Int getI() return this.i; end
      Int nonRule() return this.i; end
-     rule Int errorGet() Int v := this.nonRule(); return v; end
+     rule Int errorGet() Int v = this.nonRule(); return v; end
 end
 
 main

--- a/src/test/resources/types.smol
+++ b/src/test/resources/types.smol
@@ -3,9 +3,9 @@ class C<T, S>(Int i, Wrapper<Int> list)
     T id(T t) return t; end
     S idTwo(S s) return s; end
     Int sum(Int i1, Int i2)
-        Int get := this.list.content;
-        Int another := this.sum(get, i2);
-        this.i := this.i;
+        Int get = this.list.content;
+        Int another = this.sum(get, i2);
+        this.i = this.i;
         return i1+another;
     end
 end

--- a/src/test/resources/visible.smol
+++ b/src/test/resources/visible.smol
@@ -1,72 +1,72 @@
 
 class A (protected Int f1, private Int f2, Int f3)
     Int m1(A a, B b, C c)
-        Int v1 := this.f1 + this.f2 + this.f3;
-        Int v2 := b.f4; //fail
-        Int v3 := b.f5; //fail
-        Int v4 := b.f6;
-        Int v5 := b.f1;
-        Int v6 := b.f2;
-        Int v7 := b.f3;
-        Int w5 := a.f1;
-        Int w6 := a.f2;
-        Int w7 := a.f3;
-        Int v8 := c.f7; //fail
-        Int v9 := c.f8; //fail
-        Int v0 := c.f9;
+        Int v1 = this.f1 + this.f2 + this.f3;
+        Int v2 = b.f4; //fail
+        Int v3 = b.f5; //fail
+        Int v4 = b.f6;
+        Int v5 = b.f1;
+        Int v6 = b.f2;
+        Int v7 = b.f3;
+        Int w5 = a.f1;
+        Int w6 = a.f2;
+        Int w7 = a.f3;
+        Int v8 = c.f7; //fail
+        Int v9 = c.f8; //fail
+        Int v0 = c.f9;
         return 0;
     end
 end
 
 class B extends A (protected Int f4, private Int f5, Int f6)
     Int m2(A a, B b, C c)
-        Int v1 := this.f4 + this.f5 + this.f6;
-        Int v2 := b.f4;
-        Int v3 := b.f5;
-        Int v4 := b.f6;
-        Int v5 := b.f1;
-        Int v6 := b.f2; //fail
-        Int v7 := b.f3;
-        Int w5 := a.f1;
-        Int w6 := a.f2; //fail
-        Int w7 := a.f3;
-        Int v8 := c.f7; //fail
-        Int v9 := c.f8; //fail
-        Int v0 := c.f9;
+        Int v1 = this.f4 + this.f5 + this.f6;
+        Int v2 = b.f4;
+        Int v3 = b.f5;
+        Int v4 = b.f6;
+        Int v5 = b.f1;
+        Int v6 = b.f2; //fail
+        Int v7 = b.f3;
+        Int w5 = a.f1;
+        Int w6 = a.f2; //fail
+        Int w7 = a.f3;
+        Int v8 = c.f7; //fail
+        Int v9 = c.f8; //fail
+        Int v0 = c.f9;
         return 0;
     end
 end
 
 class C extends A(protected Int f7, private Int f8, Int f9)
     Int m3(A a, B b, C c)
-        Int v1 := this.f7 + this.f8 + this.f9;
-        Int v2 := b.f4; //fail
-        Int v3 := b.f5; //fail
-        Int v4 := b.f6;
-        Int v5 := b.f1;
-        Int v6 := b.f2; //fail
-        Int v7 := b.f3;
-        Int w5 := a.f1;
-        Int w6 := a.f2; //fail
-        Int w7 := a.f3;
-        Int v8 := c.f7;
-        Int v9 := c.f8;
-        Int v0 := c.f9;
+        Int v1 = this.f7 + this.f8 + this.f9;
+        Int v2 = b.f4; //fail
+        Int v3 = b.f5; //fail
+        Int v4 = b.f6;
+        Int v5 = b.f1;
+        Int v6 = b.f2; //fail
+        Int v7 = b.f3;
+        Int w5 = a.f1;
+        Int w6 = a.f2; //fail
+        Int w7 = a.f3;
+        Int v8 = c.f7;
+        Int v9 = c.f8;
+        Int v0 = c.f9;
         return 0;
     end
 end
 
 class D extends A()
     Int m4(A a, B b, C c)
-        a.f1 := 1;
-        a.f2 := 1; //fail
-        a.f3 := 1;
-        b.f4 := 1; //fail
-        b.f5 := 1; //fail
-        b.f6 := 1;
-        c.f7 := 1; //fail
-        c.f8 := 1; //fail
-        c.f9 := 1;
+        a.f1 = 1;
+        a.f2 = 1; //fail
+        a.f3 = 1;
+        b.f4 = 1; //fail
+        b.f5 = 1; //fail
+        b.f6 = 1;
+        c.f7 = 1; //fail
+        c.f8 = 1; //fail
+        c.f9 = 1;
         return 0;
     end
 end


### PR DESCRIPTION
As discussed offline; reviewers stumbled over `<>` when reading, and we stumble over `:=` when writing

- `:=` is now `=`, `=` is now `==`, `<>` is now `!=`.

- Algol has lost, C-style syntax is too ingrained in everyone's fingertips