### PR TITLE
Add manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /build/classes/java/main/
 *.elc
 *.yml
+/manual/build/

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.4.10'
     id 'com.github.johnrengelman.shadow' version '5.2.0'
     id 'antlr'
+    id "kr.motd.sphinx" version "2.10.0"
 }
 group = 'me.edkam'
 version = '0.2'
@@ -54,3 +55,15 @@ jar {
 compileKotlin.dependsOn generateGrammarSource
 
 assemble.dependsOn shadowJar
+
+sphinx {
+    // Documentation at
+    // https://trustin.github.io/sphinx-gradle-plugin/index.html
+    sourceDirectory = "${projectDir}/manual/source"
+    configDirectory = "${projectDir}/manual/source"
+    outputDirectory = "${projectDir}/manual/build/html"
+    builder = "html"
+}
+clean {
+    delete files("${projectDir}/manual/build")
+}

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ sphinx {
     sourceDirectory = "${projectDir}/manual/source"
     configDirectory = "${projectDir}/manual/source"
     outputDirectory = "${projectDir}/manual/build/html"
-    builder = "html"
+    builder = "singlehtml"
 }
 clean {
     delete files("${projectDir}/manual/build")

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/manual/make.bat
+++ b/manual/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/manual/source/conf.py
+++ b/manual/source/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'SMOL'
+copyright = '2022, Eduard Kamburjan, Rudolf Schlatte'
+author = 'Eduard Kamburjan, Rudolf Schlatte'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/manual/source/index.rst
+++ b/manual/source/index.rst
@@ -1,0 +1,20 @@
+.. SMOL documentation master file, created by
+   sphinx-quickstart on Wed Mar  2 16:05:25 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to SMOL's documentation!
+================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/manual/source/index.rst
+++ b/manual/source/index.rst
@@ -6,10 +6,14 @@
 Welcome to SMOL's documentation!
 ================================
 
+(Starting words about SMOL here...)
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
+   introduction
+   lexical-structure
 
 
 Indices and tables

--- a/manual/source/index.rst
+++ b/manual/source/index.rst
@@ -15,6 +15,14 @@ Welcome to SMOL's documentation!
    introduction
    lexical-structure
 
+Glossary
+========
+
+.. glossary::
+   :sorted:
+
+   EBNF
+      Extended Backus-Naur Form, a notation for formally specifying syntax.
 
 Indices and tables
 ==================

--- a/manual/source/introduction.rst
+++ b/manual/source/introduction.rst
@@ -1,0 +1,11 @@
+
+Introduction
+============
+
+The SMOL Language
+-----------------
+
+Semantic Web Technologies and SMOL
+----------------------------------
+
+

--- a/manual/source/lexical-structure.rst
+++ b/manual/source/lexical-structure.rst
@@ -1,0 +1,21 @@
+Lexical Structure
+=================
+
+This section describes the lexical structure of SMOL.  We use the following conventions: ...
+
+Line Terminators and Whitespace
+-------------------------------
+
+Comments
+--------
+
+Identifiers
+-----------
+
+Keywords
+--------
+
+Literals
+--------
+
+

--- a/manual/source/lexical-structure.rst
+++ b/manual/source/lexical-structure.rst
@@ -1,7 +1,9 @@
 Lexical Structure
 =================
 
-This section describes the lexical structure of SMOL.  We use the following conventions: ...
+This section describes the lexical structure of SMOL.  We define the grammar
+using a simple :term:`EBNF` notation as defined by `the W3C
+<https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-notation>`_.
 
 Line Terminators and Whitespace
 -------------------------------


### PR DESCRIPTION
There's no manual content for now.  Sphinx and reStructured Text documentation is at https://www.sphinx-doc.org/en/master/contents.html ; I'm currently working through https://www.sphinx-doc.org/en/master/tutorial/index.html

`./gradlew site` builds the HTML manual, entry point is `manual/build/html/index.html`

To build other formats, use the Makefile in the `manual/` subdirectory. Just calling `make` prints a list of targets, `make latexpdf` creates `manual/build/latex/smol.pdf` etc.

The gradle plugin seems to download a sphinx binary so doesn't need any external program, but `manual/Makefile` will need a local sphinx-doc install.  https://www.sphinx-doc.org/en/master/usage/installation.html has installation instructions.

